### PR TITLE
fix: restructure trigger delimiters and add missing JPA views

### DIFF
--- a/docker/init/05-triggers.sql
+++ b/docker/init/05-triggers.sql
@@ -1,7 +1,10 @@
-USE
-    shift_happens;
+USE shift_happens;
+
 DELIMITER $$
 
+-- =========================================
+-- TRIGGER: Validate and process leave approvals
+-- =========================================
 CREATE TRIGGER trg_leaveapproval_before_insert
     BEFORE INSERT
     ON leave_approval
@@ -26,8 +29,7 @@ BEGIN
     FROM leave_request
     WHERE leave_request_id = NEW.leave_request_id
     LIMIT 1
-    FOR
-    UPDATE;
+    FOR UPDATE;
 
     IF v_employee_id IS NULL THEN
         SIGNAL SQLSTATE '45000'
@@ -94,45 +96,9 @@ BEGIN
 
 END$$
 
-DELIMITER ;
-
-/*Test the leave approval trigger works*/
-
-/*Find random employee with role 2 (regular employee)*/
-SET @random_employee = (SELECT employee.employee_id
-                        FROM employee
-                        WHERE fk_user_role_id = 2
-                        ORDER BY RAND()
-                        LIMIT 1);
-/*Find random employee with role 3 (Manager, the required role for approvals)*/
-SET @random_manager = (SELECT employee.employee_id
-                       FROM employee
-                       WHERE fk_user_role_id = 3
-                       ORDER BY RAND()
-                       LIMIT 1);
-/*Add additional vacation time for a test employee from above manager*/
-INSERT INTO `leave_ledger` (`employee_id`, `leave_type_id`, `change_amount_days`, `transaction_type`,
-                            `reference_entity_type`, reference_entity_id, `transaction_datetime`)
-VALUES (@random_employee, 1, 10, 'ACCRUAL', 'Employee', @random_manager, '2026-02-24 11:00:00');
-/*set default datetime for new entries to simplify INSERTs*/
-ALTER TABLE `leave_request`
-    MODIFY requested_datetime DATETIME DEFAULT CURRENT_TIMESTAMP;
-/*Add leave request*/
-INSERT INTO `leave_request` (`employee_id`, `leave_type_id`, `start_date`, `end_date`, `request_status`, `reason`)
-VALUES (@random_employee, 1, '2026-05-05', '2026-05-08', 'PENDING', 'Vacation');
-SET @new_leave_request_id = LAST_INSERT_ID();
-
-INSERT INTO leave_approval (leave_request_id,
-                            approver_employee_id,
-                            decision,
-                            decision_datetime)
-VALUES (@new_leave_request_id, /* the leave_request_id of employee 96*/
-        @random_manager, /* NOT a manager*/
-        'APPROVED',
-        NOW());
-
-
-/*Prevent deletion of leave ledger entries*/
+-- =========================================
+-- TRIGGER: Prevent deletion of leave ledger entries
+-- =========================================
 CREATE TRIGGER trg_no_delete_leave_ledger
     BEFORE DELETE
     ON leave_ledger
@@ -140,14 +106,11 @@ CREATE TRIGGER trg_no_delete_leave_ledger
 BEGIN
     SIGNAL SQLSTATE '45000'
         SET MESSAGE_TEXT = 'Ledger entries cannot be deleted';
-END;
-/* Test DELETE
-START TRANSACTION
-DELETE FROM leave_ledger ORDER BY leave_ledger_id DESC LIMIT 1;
-ROLLBACK;
- */
+END$$
 
-/*Days cannot be 0*/
+-- =========================================
+-- TRIGGER: Days cannot be 0
+-- =========================================
 CREATE TRIGGER trg_validate_ledger_amount
     BEFORE INSERT
     ON leave_ledger
@@ -157,21 +120,11 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'Ledger change cannot be zero';
     END IF;
-END;
+END$$
 
-/* Test INSERT
-START TRANSACTION;
-INSERT INTO leave_ledger (
-    employee_id,
-    leave_type_id,
-    change_amount_days,
-    transaction_type,
-    transaction_datetime
-)
-VALUES (1, 1, 0, 'USAGE', NOW());
-ROLLBACK;
-*/
-
+-- =========================================
+-- TRIGGER: Prevent changing employee on leave request
+-- =========================================
 CREATE TRIGGER trg_prevent_employee_change
     BEFORE UPDATE
     ON leave_request
@@ -181,37 +134,12 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'Employee cannot be changed';
     END IF;
-END;
+END$$
 
-/*
--- Test the trigger
--- Start safe test transaction
-START TRANSACTION;
-
--- Step 1: Get one leave request
-SELECT leave_request_id, employee_id
-INTO @v_leave_request_id, @v_old_employee_id
-FROM leave_request
-LIMIT 1;
-
--- Step 2: Find a different employee
-SELECT employee_id
-INTO @v_new_employee_id
-FROM employee
-WHERE employee_id <> @v_old_employee_id
-LIMIT 1;
-
--- Step 3: Attempt to update (THIS SHOULD FAIL)
-UPDATE leave_request
-SET employee_id = @v_new_employee_id
-WHERE leave_request_id = @v_leave_request_id;
-
--- Rollback so nothing changes even if trigger is disabled
-ROLLBACK;
-*/
-
-DELIMITER $$
-DROP TRIGGER IF EXISTS trg_validate_employee_ins;
+-- =========================================
+-- TRIGGER: Validate employee password length (INSERT)
+-- =========================================
+DROP TRIGGER IF EXISTS trg_validate_employee_ins$$
 CREATE TRIGGER trg_validate_employee_ins
     BEFORE INSERT
     ON employee
@@ -221,8 +149,12 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'Password needs to be longer than 8 chars.';
     END IF;
-end $$
-DROP TRIGGER IF EXISTS trg_validate_employee_update;
+END$$
+
+-- =========================================
+-- TRIGGER: Validate employee password length (UPDATE)
+-- =========================================
+DROP TRIGGER IF EXISTS trg_validate_employee_update$$
 CREATE TRIGGER trg_validate_employee_update
     BEFORE UPDATE
     ON employee
@@ -232,9 +164,12 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'Password needs to be longer than 8 chars.';
     END IF;
-end $$
+END$$
 
-DROP TRIGGER IF EXISTS trg_validate_contract_ins;
+-- =========================================
+-- TRIGGER: Validate contract fields (INSERT)
+-- =========================================
+DROP TRIGGER IF EXISTS trg_validate_contract_ins$$
 CREATE TRIGGER trg_validate_contract_ins
     BEFORE INSERT
     ON employee_contract
@@ -252,9 +187,12 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'start_date cannot be after end_date';
     END IF;
-end $$
+END$$
 
-DROP TRIGGER IF EXISTS trg_validate_contract_update;
+-- =========================================
+-- TRIGGER: Validate contract fields (UPDATE)
+-- =========================================
+DROP TRIGGER IF EXISTS trg_validate_contract_update$$
 CREATE TRIGGER trg_validate_contract_update
     BEFORE UPDATE
     ON employee_contract
@@ -272,10 +210,12 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'start_date cannot be after end_date';
     END IF;
-end $$
+END$$
 
-DROP TRIGGER IF EXISTS trg_no_contract_overlap_ins;
-
+-- =========================================
+-- TRIGGER: Prevent overlapping active contracts (INSERT)
+-- =========================================
+DROP TRIGGER IF EXISTS trg_no_contract_overlap_ins$$
 CREATE TRIGGER trg_no_contract_overlap_ins
     BEFORE INSERT
     ON employee_contract
@@ -285,16 +225,18 @@ BEGIN
                                      FROM employee_contract ec
                                      WHERE ec.employee_id = NEW.employee_id
                                        AND ec.is_active = 1
-                                       AND NEW.start_date <= IFNULL(ec.end_date, '9999-12-31') -- New contract starts before an existing active contract ended
-                                       AND ec.start_date <= IFNULL(NEW.end_date, '9999-12-31') -- Existing contract starts before new contract ends
+                                       AND NEW.start_date <= IFNULL(ec.end_date, '9999-12-31')
+                                       AND ec.start_date <= IFNULL(NEW.end_date, '9999-12-31')
     ) THEN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'Contract period overlaps with an existing active contract.';
     END IF;
-END $$
+END$$
 
-DROP TRIGGER IF EXISTS trg_no_contract_overlap_upd;
-
+-- =========================================
+-- TRIGGER: Prevent overlapping active contracts (UPDATE)
+-- =========================================
+DROP TRIGGER IF EXISTS trg_no_contract_overlap_upd$$
 CREATE TRIGGER trg_no_contract_overlap_upd
     BEFORE UPDATE
     ON employee_contract
@@ -310,22 +252,12 @@ BEGIN
         SIGNAL SQLSTATE '45000'
             SET MESSAGE_TEXT = 'Contract period overlaps with an existing active contract.';
     END IF;
-END $$
+END$$
 
-
-/*
- AUDIT Triggers
- */
-
-/*
-* Logs for Employee table
-*/
-
-DROP TRIGGER IF EXISTS trg_employee_insert;
-
-DELIMITER $$
-
--- 1️⃣ Audit INSERT
+-- =========================================
+-- AUDIT TRIGGERS: Employee table
+-- =========================================
+DROP TRIGGER IF EXISTS trg_employee_insert$$
 CREATE TRIGGER trg_employee_insert
     AFTER INSERT
     ON employee
@@ -354,16 +286,12 @@ BEGIN
                     'hire_date', NEW.hire_date,
                     'employment_status', NEW.employment_status,
                     'primary_work_location_id', NEW.primary_work_location_id,
-                    'login_password', '*****', -- hidden password
+                    'login_password', '*****',
                     'fk_user_role_id', NEW.fk_user_role_id
             ));
 END$$
 
-
--- Audit UPDATEs
--- 2️⃣ Audit UPDATE
-DROP TRIGGER IF EXISTS trg_employee_update;
-
+DROP TRIGGER IF EXISTS trg_employee_update$$
 CREATE TRIGGER trg_employee_update
     BEFORE UPDATE
     ON employee
@@ -391,7 +319,7 @@ BEGIN
                     'hire_date', OLD.hire_date,
                     'employment_status', OLD.employment_status,
                     'primary_work_location_id', OLD.primary_work_location_id,
-                    'login_password', '*****', -- Password hidden
+                    'login_password', '*****',
                     'fk_user_role_id', OLD.fk_user_role_id
             ),
             JSON_OBJECT(
@@ -404,13 +332,12 @@ BEGIN
                     'hire_date', NEW.hire_date,
                     'employment_status', NEW.employment_status,
                     'primary_work_location_id', NEW.primary_work_location_id,
-                    'login_password', '*****', -- Password hidden
+                    'login_password', '*****',
                     'fk_user_role_id', NEW.fk_user_role_id
             ));
 END$$
 
-DROP TRIGGER IF EXISTS trg_employee_delete;
--- 3️⃣ Audit DELETEs
+DROP TRIGGER IF EXISTS trg_employee_delete$$
 CREATE TRIGGER trg_employee_delete
     BEFORE DELETE
     ON employee
@@ -438,7 +365,7 @@ BEGIN
                     'hire_date', OLD.hire_date,
                     'employment_status', OLD.employment_status,
                     'primary_work_location_id', OLD.primary_work_location_id,
-                    'login_password', '*****', -- Password hidden
+                    'login_password', '*****',
                     'fk_user_role_id', OLD.fk_user_role_id
             ),
             NULL);
@@ -446,7 +373,45 @@ END$$
 
 DELIMITER ;
 
-/* TEST above triggers */
+-- =========================================
+-- TEST: Leave approval trigger
+-- =========================================
+
+SET @random_employee = (SELECT employee.employee_id
+                        FROM employee
+                        WHERE fk_user_role_id = 2
+                        ORDER BY RAND()
+                        LIMIT 1);
+
+SET @random_manager = (SELECT employee.employee_id
+                       FROM employee
+                       WHERE fk_user_role_id = 3
+                       ORDER BY RAND()
+                       LIMIT 1);
+
+INSERT INTO `leave_ledger` (`employee_id`, `leave_type_id`, `change_amount_days`, `transaction_type`,
+                            `reference_entity_type`, reference_entity_id, `transaction_datetime`)
+VALUES (@random_employee, 1, 10, 'ACCRUAL', 'Employee', @random_manager, '2026-02-24 11:00:00');
+
+ALTER TABLE `leave_request`
+    MODIFY requested_datetime DATETIME DEFAULT CURRENT_TIMESTAMP;
+
+INSERT INTO `leave_request` (`employee_id`, `leave_type_id`, `start_date`, `end_date`, `request_status`, `reason`)
+VALUES (@random_employee, 1, '2026-05-05', '2026-05-08', 'PENDING', 'Vacation');
+SET @new_leave_request_id = LAST_INSERT_ID();
+
+INSERT INTO leave_approval (leave_request_id,
+                            approver_employee_id,
+                            decision,
+                            decision_datetime)
+VALUES (@new_leave_request_id,
+        @random_manager,
+        'APPROVED',
+        NOW());
+
+-- =========================================
+-- TEST: Audit triggers
+-- =========================================
 
 INSERT INTO employee (employee_number, first_name, last_name, email, login_password, fk_user_role_id,
                       phone_number, hire_date, employment_status, primary_work_location_id)

--- a/docker/init/07-views.sql
+++ b/docker/init/07-views.sql
@@ -72,3 +72,62 @@ FROM leave_request lr
          JOIN employee e ON lr.employee_id = e.employee_id
          JOIN leave_type lt ON lr.leave_type_id = lt.leave_type_id
 WHERE lr.request_status = 'PENDING';
+
+-- =========================================
+-- VIEW: Employee shift overview (JPA mapped)
+-- =========================================
+CREATE OR REPLACE VIEW vw_employee_shift_overview AS
+SELECT sa.shift_assignment_id,
+       e.employee_id,
+       e.employee_number,
+       e.first_name,
+       e.last_name,
+       e.email,
+       s.shift_id,
+       s.shift_name,
+       s.start_datetime,
+       s.end_datetime,
+       s.shift_status,
+       d.department_name,
+       wl.location_name,
+       sa.assignment_status,
+       sa.assigned_datetime,
+       sa.check_in_datetime,
+       sa.check_out_datetime
+FROM shift_assignment sa
+         JOIN employee e ON sa.employee_id = e.employee_id
+         JOIN shift s ON sa.shift_id = s.shift_id
+         JOIN department d ON s.department_id = d.department_id
+         JOIN work_location wl ON s.work_location_id = wl.work_location_id;
+
+-- =========================================
+-- VIEW: Employee leave overview (JPA mapped)
+-- =========================================
+CREATE OR REPLACE VIEW vw_employee_leave_overview AS
+SELECT lr.leave_request_id,
+       e.employee_id,
+       e.employee_number,
+       e.first_name,
+       e.last_name,
+       e.email,
+       lt.leave_type_id,
+       lt.leave_type_name,
+       lt.is_paid_leave,
+       lt.requires_approval,
+       lr.start_date,
+       lr.end_date,
+       lr.request_status,
+       lr.reason,
+       lr.requested_datetime,
+       la.leave_approval_id,
+       la.decision        AS approval_decision,
+       la.leave_comment   AS approval_comment,
+       la.decision_datetime AS approval_datetime,
+       approver.employee_number AS approver_number,
+       approver.first_name      AS approver_first_name,
+       approver.last_name       AS approver_last_name
+FROM leave_request lr
+         JOIN employee e ON lr.employee_id = e.employee_id
+         JOIN leave_type lt ON lr.leave_type_id = lt.leave_type_id
+         LEFT JOIN leave_approval la ON lr.leave_request_id = la.leave_request_id
+         LEFT JOIN employee approver ON la.approver_employee_id = approver.employee_id;


### PR DESCRIPTION
- Restructure 05-triggers.sql to use a single DELIMITER $$ block for all triggers, with plain SQL test statements at the end after DELIMITER ; — fixes MySQL batch mode parsing failures

- Add vw_employee_shift_overview and vw_employee_leave_overview to 07-views.sql matching the column names expected by the JPA entities