### PR TITLE
Use DTOs in all MongoDB controllers instead of raw documents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — 12-rule template
+
+These rules apply to every task in this project unless explicitly overridden.
+Bias: caution over speed on non-trivial work.
+
+## Rule 1 — Think Before Coding
+State assumptions explicitly. Ask rather than guess.
+Push back when a simpler approach exists. Stop when confused.
+
+## Rule 2 — Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+No abstractions for single-use code.
+
+## Rule 3 — Surgical Changes
+Touch only what you must. Don't improve adjacent code.
+Match existing style. Don't refactor what isn't broken.
+
+## Rule 4 — Goal-Driven Execution
+Define success criteria. Loop until verified.
+Strong success criteria let Claude loop independently.
+
+## Rule 5 — Use the model only for judgment calls
+Use for: classification, drafting, summarization, extraction.
+Do NOT use for: routing, retries, deterministic transforms.
+If code can answer, code answers.
+
+## Rule 6 — Token budgets are not advisory
+Per-task: 4,000 tokens. Per-session: 30,000 tokens.
+If approaching budget, summarize and start fresh.
+Surface the breach. Do not silently overrun.
+
+## Rule 7 — Surface conflicts, don't average them
+If two patterns contradict, pick one (more recent / more tested).
+Explain why. Flag the other for cleanup.
+
+## Rule 8 — Read before you write
+Before adding code, read exports, immediate callers, shared utilities.
+If unsure why existing code is structured a certain way, ask.
+
+## Rule 9 — Tests verify intent, not just behavior
+Tests must encode WHY behavior matters, not just WHAT it does.
+A test that can't fail when business logic changes is wrong.
+
+## Rule 10 — Checkpoint after every significant step
+Summarize what was done, what's verified, what's left.
+Don't continue from a state you can't describe back.
+
+## Rule 11 — Match the codebase's conventions, even if you disagree
+Conformance > taste inside the codebase.
+If you think a convention is harmful, surface it. Don't fork silently.
+
+## Rule 12 — Fail loud
+"Completed" is wrong if anything was skipped silently.
+"Tests pass" is wrong if any were skipped.
+Default to surfacing uncertainty, not hiding it.

--- a/docs/db-mandatory-progress.md
+++ b/docs/db-mandatory-progress.md
@@ -1,0 +1,81 @@
+# DB Mandatory — Progress & Handoff
+
+State of the DTO + layered-architecture work on the `shift_happens` project.
+Read this first when resuming. Companion docs: `dto-rationale.md`,
+`service-layer.md`.
+
+## Assignment requirements — status
+
+From the assignment: *"Apply layered architecture: controllers -> services ->
+models / repositories ... use DTO objects in the controllers. Do not expose
+the models to the outside."*
+
+| Requirement | Status |
+|---|---|
+| DTOs in all controllers (no raw entities exposed) | ✅ Done — JPA, Mongo, Neo4j |
+| Layered architecture (controllers → services → repositories) | ✅ Done — all 35 controllers |
+| `/mongo/audit_log` admin-restriction | ⬜ **Open — the one remaining task** |
+
+## The open PR stack (4 PRs, stacked — merge bottom-up)
+
+| PR | Branch | Base | Scope |
+|---|---|---|---|
+| #109 | `feature/controller-dtos` | `main` | DTOs for 17 SQL/JPA controllers |
+| #111 | `feature/mongo-controller-dtos` | `feature/controller-dtos` | DTOs for 8 MongoDB controllers |
+| #112 | `feature/neo4j-controller-dtos` | `feature/mongo-controller-dtos` | DTOs for 10 Neo4j controllers |
+| #114 | `feature/service-layer` | `feature/neo4j-controller-dtos` | Service layer for all 35 controllers |
+
+**Merge order: #109 → #111 → #112 → #114.** Each PR's base retargets to `main`
+automatically as the one below it merges. Each PR shows only its own diff.
+
+Repo: `https://github.com/Luke3520/shift_happens.git`
+
+## Conventions established (follow these if extending the work)
+
+- **DTOs are Java `record`s** with a static `from(...)` factory and a
+  `toEntity()` method. Naming: JPA `XDto`, Mongo `XDocumentDto`, Neo4j
+  `XNodeDto` (distinct names avoid cross-package clashes).
+- **Sensitive fields:** `loginPassword` is write-only (`@JsonProperty(WRITE_ONLY)`);
+  `salaryAmount` is dropped from DTOs entirely.
+- **Services** are thin `@Service @RequiredArgsConstructor` delegates exposing
+  `findAll / findById / create / update / delete`. New services' `findById`
+  and `update` return `Optional`; the controller maps to the HTTP response.
+- No co-author / "Generated with Claude Code" trailers in commits or PRs.
+
+## THE REMAINING TASK — fix `/mongo/audit_log` authorization
+
+**Problem:** `SecurityConfig` (`auth/SecurityConfig.java`) secures all requests
+by URL. Its rule `/auditlogs/**` → `hasRole("ADMINISTRATOR")` restricts the JPA
+audit log to admins. But `AuditLogMongoController` is mapped at
+`/mongo/audit_log` — which that rule does NOT match. So the Mongo audit log is
+readable by any authenticated user (including a plain EMPLOYEE). Inconsistent
+with the JPA side.
+
+**Fix:** in `SecurityConfig.securityFilterChain`, add a matcher for the Mongo
+audit-log path next to the existing `/auditlogs/**` rule:
+
+```java
+.requestMatchers("/auditlogs/**").hasRole("ADMINISTRATOR")
+.requestMatchers("/mongo/audit_log/**").hasRole("ADMINISTRATOR")  // add this
+```
+
+(There is no Neo4j audit-log controller, so nothing is needed there.)
+
+**Do it as a new branch/PR** stacked on `feature/service-layer`
+(`feature/mongo-auditlog-auth` → base `feature/service-layer`). Verify with
+`mvn test` (expect 6/6 pass, `BUILD SUCCESS`).
+
+## Deliberately NOT done (defensible non-goals)
+
+- **`@PreAuthorize` on Mongo/Neo4j controllers** — redundant. `SecurityConfig`'s
+  filter chain already authenticates every request and requires ADMIN/MANAGER
+  for POST/PUT/PATCH/DELETE on `/**`. The JPA `@PreAuthorize` annotations are
+  belt-and-suspenders; replicating them adds no real access control.
+- **Per-row employee-scoping on Mongo/Neo4j** — the JPA side uses `AuthHelper`
+  so an EMPLOYEE sees only their own rows. Mongo/Neo4j lack this. Left as a
+  known limitation: those endpoints are parallel demo surfaces, not consumed
+  by the frontend.
+- **Consumer-driven / view-specific DTOs** — the 3 denormalised Mongo
+  aggregates are mirrored 1:1. Best practice would be smaller, use-case-shaped
+  DTOs, but there is no frontend consumer to design against. See
+  `dto-rationale.md`.

--- a/docs/dto-rationale.md
+++ b/docs/dto-rationale.md
@@ -106,10 +106,7 @@ Two details specific to Neo4j:
 
 ## Known follow-ups (out of scope here)
 
-- **Mongo and Neo4j controllers have no service layer** — they call
-  repositories directly, whereas the assignment asks for
-  `controllers -> services -> repositories`. Not addressed in this
-  DTO-focused change.
+- **Service layer** — added in a follow-up branch; see `docs/service-layer.md`.
 - **Mongo and Neo4j controllers have no `@PreAuthorize`** — they are
   unauthenticated, unlike the JPA controllers. A separate security concern.
 

--- a/docs/dto-rationale.md
+++ b/docs/dto-rationale.md
@@ -84,17 +84,37 @@ Honest answer: the value varies.
 A DTO is an API-boundary concern, not a SQL-specific one — it applies equally
 to JPA entities, Mongo documents and Neo4j nodes.
 
+## Neo4j controllers
+
+The same approach was applied to the **10 Neo4j controllers**. DTOs there are
+named `XNodeDto` to avoid clashing with the JPA-side `XDto` and the Mongo-side
+`XDocumentDto`.
+
+All 10 Neo4j nodes are **flat** — no `@Relationship` mappings, no embedded
+structure — so every DTO is a flat record, no nested mirroring needed. There
+are also **no sensitive fields** (unlike Mongo, `EmployeeNode` has no
+password), so no write-only / dropped-field handling was required.
+
+Two details specific to Neo4j:
+
+- 5 of the 10 controllers are **read-only** (`getAll` / `getById`), so their
+  DTOs only need a `from()` factory — no `toEntity()`.
+- `ShiftSwapNeo4jController` also has three Cypher-query endpoints that return
+  `List<Map<String, Object>>` projections. A `Map` is a query result, not a
+  persistence model, so those endpoints are left as-is — consistent with
+  `Neo4jInsightsController`, which was excluded for the same reason.
+
 ## Known follow-ups (out of scope here)
 
-- **Neo4j controllers** still return `@Node` entities — a later branch.
-- **Mongo controllers have no service layer** — they call repositories
-  directly, whereas the assignment asks for `controllers -> services ->
-  repositories`. Not addressed in this DTO-focused change.
-- **Mongo controllers have no `@PreAuthorize`** — they are unauthenticated,
-  unlike the JPA controllers. A separate security concern.
+- **Mongo and Neo4j controllers have no service layer** — they call
+  repositories directly, whereas the assignment asks for
+  `controllers -> services -> repositories`. Not addressed in this
+  DTO-focused change.
+- **Mongo and Neo4j controllers have no `@PreAuthorize`** — they are
+  unauthenticated, unlike the JPA controllers. A separate security concern.
 
 ## Scope
 
-Migrated: the **17 SQL/JPA controllers** and the **8 MongoDB controllers**.
-`AuthController` already uses POJOs; `MigrationController` and
-`Neo4jInsightsController` do not expose entities.
+Migrated: the **17 SQL/JPA controllers**, the **8 MongoDB controllers**, and
+the **10 Neo4j controllers**. `AuthController` already uses POJOs;
+`MigrationController` and `Neo4jInsightsController` do not expose entities.

--- a/docs/dto-rationale.md
+++ b/docs/dto-rationale.md
@@ -51,14 +51,50 @@ raw persistence entities to returning DTOs, and the design choices behind it.
 - **`Optional<XDto>` return types** (Shift, ShiftApproval, etc.) were kept
   as-is to keep the migration behavior-preserving.
 
+## MongoDB controllers
+
+The same approach was applied to the **8 MongoDB controllers**. DTOs there are
+named `XDocumentDto` to avoid clashing with the JPA-side `XDto` in the parent
+package.
+
+The Mongo documents fall into two tiers:
+
+- **Flat reference documents (5)** — Department, JobRole, LeaveType,
+  WorkLocation, AuditLog. Same trivial flat-DTO treatment as the JPA entities.
+- **Denormalised aggregate documents (3)** — Employee, Shift, Leave. These are
+  deep trees of embedded sub-documents (a Mongo document is deliberately
+  designed as a read model, joined at write time instead of read time). Each
+  embedded sub-document is mirrored by a nested DTO `record` — about 19 nested
+  records in total.
+
+### Is mirroring the nested documents worth it?
+
+Honest answer: the value varies.
+
+- For `EmployeeDocument` it is real — `loginPassword` was exposed with **no**
+  protection at all (unlike the JPA `Employee`), and `salaryAmount` sat
+  unprotected inside an embedded contract. The DTO closes both:
+  `loginPassword` is write-only, `salaryAmount` is dropped.
+- For `ShiftDocument` and `LeaveDocument` there is no sensitive data, so their
+  nested DTOs are mostly **consistency** value: every controller returns a
+  DTO, with no exceptions to explain. The requirement ("use DTO objects in the
+  controllers") is unconditional, and a complete, uniform rule is easier to
+  defend than a judgement-based carve-out.
+
+A DTO is an API-boundary concern, not a SQL-specific one — it applies equally
+to JPA entities, Mongo documents and Neo4j nodes.
+
+## Known follow-ups (out of scope here)
+
+- **Neo4j controllers** still return `@Node` entities — a later branch.
+- **Mongo controllers have no service layer** — they call repositories
+  directly, whereas the assignment asks for `controllers -> services ->
+  repositories`. Not addressed in this DTO-focused change.
+- **Mongo controllers have no `@PreAuthorize`** — they are unauthenticated,
+  unlike the JPA controllers. A separate security concern.
+
 ## Scope
 
-Migrated: the **17 SQL/JPA controllers** (Employee, Department, Shift,
-JobRole, LeaveType, WorkLocation, LeaveRequest, LeaveApproval, ShiftApproval,
-ShiftAssignment, ShiftSwap, ShiftSwapApproval, LeaveLedger, EmployeeContract,
-EmployeeJobRole, ShiftRequiredJobRole, AuditLog).
-
-Deferred to a later branch: the 12 MongoDB and 13 Neo4j controllers, which
-still return `@Document` / `@Node` entities. `AuthController` already uses
-POJOs; `MigrationController` and `Neo4jInsightsController` do not expose
-entities.
+Migrated: the **17 SQL/JPA controllers** and the **8 MongoDB controllers**.
+`AuthController` already uses POJOs; `MigrationController` and
+`Neo4jInsightsController` do not expose entities.

--- a/docs/service-layer.md
+++ b/docs/service-layer.md
@@ -1,0 +1,44 @@
+# Service Layer — Rationale
+
+## Requirement
+
+> "Apply layered architecture: controllers -> services -> models / repositories."
+> — assignment brief
+
+## What was done
+
+Before this change only **5 of 17 JPA controllers** had a service; the Mongo
+and Neo4j controllers had none and called their repositories directly. Every
+controller now goes through a service:
+
+| Store | Controllers | Services added |
+|---|---|---|
+| JPA   | 17 | 12 (5 already existed) |
+| Mongo | 8  | 8 |
+| Neo4j | 10 | 9 (`ShiftSwapNeo4jService` already existed; extended) |
+
+The dependency chain is now uniformly `controller -> service -> repository`
+for all 35 controllers.
+
+## Design
+
+- **Thin delegating services.** Each service is `@Service @RequiredArgsConstructor`,
+  holds the repository, and exposes `findAll / findById / create / update /
+  delete`. No business logic was invented — adding any would be speculative.
+- **`findById` / `update` return `Optional`.** The service stays free of HTTP
+  concerns; the controller decides the HTTP response (404, empty body, etc.).
+  This follows the existing `LeaveRequestService.patch` precedent. The older
+  `DepartmentService` throws `ResponseStatusException` internally instead — a
+  minor pre-existing inconsistency, left untouched to keep this change surgical.
+- **Behaviour preserved.** Field-copy logic in `update` moved verbatim from the
+  controllers into the services; every endpoint's status codes are unchanged.
+- **Neo4j `ShiftSwap`.** The existing `ShiftSwapNeo4jService` was extended with
+  `findAll` / `findById` and the two Cypher candidate-queries, so the controller
+  no longer talks to `Neo4jClient` or the repository directly.
+
+## Known follow-ups (still out of scope)
+
+- **No `@PreAuthorize` on Mongo / Neo4j controllers** — a separate security
+  concern.
+- **`DepartmentService` style divergence** — older services throw from
+  `findById`; new ones return `Optional`. Could be aligned later.

--- a/src/main/java/dk/ek/shift_happens/auditlog/AuditLogController.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/AuditLogController.java
@@ -12,10 +12,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuditLogController {
 
-    private final AuditLogRepository auditLogRepository;
+    private final AuditLogService auditLogService;
 
     @GetMapping
     public List<AuditLogDto> getAuditLogs() {
-        return this.auditLogRepository.findAll().stream().map(AuditLogDto::from).toList();
+        return this.auditLogService.findAll().stream().map(AuditLogDto::from).toList();
     }
 }

--- a/src/main/java/dk/ek/shift_happens/auditlog/AuditLogService.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/AuditLogService.java
@@ -1,0 +1,17 @@
+package dk.ek.shift_happens.auditlog;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public List<AuditLog> findAll() {
+        return auditLogRepository.findAll();
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogDocumentDto.java
@@ -1,0 +1,40 @@
+package dk.ek.shift_happens.auditlog.mongo;
+
+import java.time.LocalDateTime;
+
+public record AuditLogDocumentDto(
+        String id,
+        String entityType,
+        Integer entityId,
+        String actionType,
+        String dbUser,
+        LocalDateTime actionDatetime,
+        String oldValueSnapshot,
+        String newValueSnapshot
+) {
+    public static AuditLogDocumentDto from(AuditLogDocument a) {
+        return new AuditLogDocumentDto(
+                a.getId(),
+                a.getEntityType(),
+                a.getEntityId(),
+                a.getActionType(),
+                a.getDbUser(),
+                a.getActionDatetime(),
+                a.getOldValueSnapshot(),
+                a.getNewValueSnapshot()
+        );
+    }
+
+    public AuditLogDocument toEntity() {
+        AuditLogDocument a = new AuditLogDocument();
+        a.setId(id);
+        a.setEntityType(entityType);
+        a.setEntityId(entityId);
+        a.setActionType(actionType);
+        a.setDbUser(dbUser);
+        a.setActionDatetime(actionDatetime);
+        a.setOldValueSnapshot(oldValueSnapshot);
+        a.setNewValueSnapshot(newValueSnapshot);
+        return a;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuditLogMongoController {
 
-    private final AuditLogMongoRepository auditLogMongoRepository;
+    private final AuditLogMongoService auditLogMongoService;
 
     @GetMapping
     public List<AuditLogDocumentDto> getAll() {
-        return auditLogMongoRepository.findAll().stream().map(AuditLogDocumentDto::from).toList();
+        return auditLogMongoService.findAll().stream().map(AuditLogDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public AuditLogDocumentDto getById(@PathVariable String id) {
-        return auditLogMongoRepository.findById(id)
+        return auditLogMongoService.findById(id)
                 .map(AuditLogDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public AuditLogDocumentDto create(@RequestBody AuditLogDocumentDto auditLog) {
-        return AuditLogDocumentDto.from(auditLogMongoRepository.save(auditLog.toEntity()));
+        return AuditLogDocumentDto.from(auditLogMongoService.create(auditLog.toEntity()));
     }
 
     @PutMapping("/{id}")
     public AuditLogDocumentDto update(@PathVariable String id, @RequestBody AuditLogDocumentDto auditLog) {
-        if (!auditLogMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        AuditLogDocument entity = auditLog.toEntity();
-        entity.setId(id);
-        return AuditLogDocumentDto.from(auditLogMongoRepository.save(entity));
+        return auditLogMongoService.update(id, auditLog.toEntity())
+                .map(AuditLogDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!auditLogMongoRepository.existsById(id)) {
+        if (!auditLogMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        auditLogMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoController.java
@@ -15,28 +15,30 @@ public class AuditLogMongoController {
     private final AuditLogMongoRepository auditLogMongoRepository;
 
     @GetMapping
-    public List<AuditLogDocument> getAll() {
-        return auditLogMongoRepository.findAll();
+    public List<AuditLogDocumentDto> getAll() {
+        return auditLogMongoRepository.findAll().stream().map(AuditLogDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public AuditLogDocument getById(@PathVariable String id) {
+    public AuditLogDocumentDto getById(@PathVariable String id) {
         return auditLogMongoRepository.findById(id)
+                .map(AuditLogDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public AuditLogDocument create(@RequestBody AuditLogDocument auditLog) {
-        return auditLogMongoRepository.save(auditLog);
+    public AuditLogDocumentDto create(@RequestBody AuditLogDocumentDto auditLog) {
+        return AuditLogDocumentDto.from(auditLogMongoRepository.save(auditLog.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public AuditLogDocument update(@PathVariable String id, @RequestBody AuditLogDocument auditLog) {
+    public AuditLogDocumentDto update(@PathVariable String id, @RequestBody AuditLogDocumentDto auditLog) {
         if (!auditLogMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        auditLog.setId(id);
-        return auditLogMongoRepository.save(auditLog);
+        AuditLogDocument entity = auditLog.toEntity();
+        entity.setId(id);
+        return AuditLogDocumentDto.from(auditLogMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.auditlog.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogMongoService {
+
+    private final AuditLogMongoRepository auditLogMongoRepository;
+
+    public List<AuditLogDocument> findAll() {
+        return auditLogMongoRepository.findAll();
+    }
+
+    public Optional<AuditLogDocument> findById(String id) {
+        return auditLogMongoRepository.findById(id);
+    }
+
+    public AuditLogDocument create(AuditLogDocument document) {
+        return auditLogMongoRepository.save(document);
+    }
+
+    public Optional<AuditLogDocument> update(String id, AuditLogDocument document) {
+        if (!auditLogMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(auditLogMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!auditLogMongoRepository.existsById(id)) {
+            return false;
+        }
+        auditLogMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentDocumentDto.java
@@ -1,0 +1,26 @@
+package dk.ek.shift_happens.department.mongo;
+
+public record DepartmentDocumentDto(
+        String id,
+        Integer departmentId,
+        String departmentName,
+        Boolean isActive
+) {
+    public static DepartmentDocumentDto from(DepartmentDocument d) {
+        return new DepartmentDocumentDto(
+                d.getId(),
+                d.getDepartmentId(),
+                d.getDepartmentName(),
+                d.getIsActive()
+        );
+    }
+
+    public DepartmentDocument toEntity() {
+        DepartmentDocument d = new DepartmentDocument();
+        d.setId(id);
+        d.setDepartmentId(departmentId);
+        d.setDepartmentName(departmentName);
+        d.setIsActive(isActive);
+        return d;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoController.java
@@ -15,28 +15,30 @@ public class DepartmentMongoController {
     private final DepartmentMongoRepository departmentMongoRepository;
 
     @GetMapping
-    public List<DepartmentDocument> getAll() {
-        return departmentMongoRepository.findAll();
+    public List<DepartmentDocumentDto> getAll() {
+        return departmentMongoRepository.findAll().stream().map(DepartmentDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public DepartmentDocument getById(@PathVariable String id) {
+    public DepartmentDocumentDto getById(@PathVariable String id) {
         return departmentMongoRepository.findById(id)
+                .map(DepartmentDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public DepartmentDocument create(@RequestBody DepartmentDocument department) {
-        return departmentMongoRepository.save(department);
+    public DepartmentDocumentDto create(@RequestBody DepartmentDocumentDto department) {
+        return DepartmentDocumentDto.from(departmentMongoRepository.save(department.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public DepartmentDocument update(@PathVariable String id, @RequestBody DepartmentDocument department) {
+    public DepartmentDocumentDto update(@PathVariable String id, @RequestBody DepartmentDocumentDto department) {
         if (!departmentMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        department.setId(id);
-        return departmentMongoRepository.save(department);
+        DepartmentDocument entity = department.toEntity();
+        entity.setId(id);
+        return DepartmentDocumentDto.from(departmentMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DepartmentMongoController {
 
-    private final DepartmentMongoRepository departmentMongoRepository;
+    private final DepartmentMongoService departmentMongoService;
 
     @GetMapping
     public List<DepartmentDocumentDto> getAll() {
-        return departmentMongoRepository.findAll().stream().map(DepartmentDocumentDto::from).toList();
+        return departmentMongoService.findAll().stream().map(DepartmentDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public DepartmentDocumentDto getById(@PathVariable String id) {
-        return departmentMongoRepository.findById(id)
+        return departmentMongoService.findById(id)
                 .map(DepartmentDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public DepartmentDocumentDto create(@RequestBody DepartmentDocumentDto department) {
-        return DepartmentDocumentDto.from(departmentMongoRepository.save(department.toEntity()));
+        return DepartmentDocumentDto.from(departmentMongoService.create(department.toEntity()));
     }
 
     @PutMapping("/{id}")
     public DepartmentDocumentDto update(@PathVariable String id, @RequestBody DepartmentDocumentDto department) {
-        if (!departmentMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        DepartmentDocument entity = department.toEntity();
-        entity.setId(id);
-        return DepartmentDocumentDto.from(departmentMongoRepository.save(entity));
+        return departmentMongoService.update(id, department.toEntity())
+                .map(DepartmentDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!departmentMongoRepository.existsById(id)) {
+        if (!departmentMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        departmentMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.department.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentMongoService {
+
+    private final DepartmentMongoRepository departmentMongoRepository;
+
+    public List<DepartmentDocument> findAll() {
+        return departmentMongoRepository.findAll();
+    }
+
+    public Optional<DepartmentDocument> findById(String id) {
+        return departmentMongoRepository.findById(id);
+    }
+
+    public DepartmentDocument create(DepartmentDocument document) {
+        return departmentMongoRepository.save(document);
+    }
+
+    public Optional<DepartmentDocument> update(String id, DepartmentDocument document) {
+        if (!departmentMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(departmentMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!departmentMongoRepository.existsById(id)) {
+            return false;
+        }
+        departmentMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jController.java
@@ -15,13 +15,14 @@ public class DepartmentNeo4jController {
     private final DepartmentNeo4jRepository departmentNeo4jRepository;
 
     @GetMapping
-    public List<DepartmentNode> getAll() {
-        return departmentNeo4jRepository.findAll();
+    public List<DepartmentNodeDto> getAll() {
+        return departmentNeo4jRepository.findAll().stream().map(DepartmentNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public DepartmentNode getById(@PathVariable Long id) {
+    public DepartmentNodeDto getById(@PathVariable Long id) {
         return departmentNeo4jRepository.findById(id)
+                .map(DepartmentNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DepartmentNeo4jController {
 
-    private final DepartmentNeo4jRepository departmentNeo4jRepository;
+    private final DepartmentNeo4jService departmentNeo4jService;
 
     @GetMapping
     public List<DepartmentNodeDto> getAll() {
-        return departmentNeo4jRepository.findAll().stream().map(DepartmentNodeDto::from).toList();
+        return departmentNeo4jService.findAll().stream().map(DepartmentNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public DepartmentNodeDto getById(@PathVariable Long id) {
-        return departmentNeo4jRepository.findById(id)
+        return departmentNeo4jService.findById(id)
                 .map(DepartmentNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.department.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentNeo4jService {
+
+    private final DepartmentNeo4jRepository departmentNeo4jRepository;
+
+    public List<DepartmentNode> findAll() {
+        return departmentNeo4jRepository.findAll();
+    }
+
+    public Optional<DepartmentNode> findById(Long id) {
+        return departmentNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNodeDto.java
@@ -1,0 +1,17 @@
+package dk.ek.shift_happens.department.neo4j;
+
+public record DepartmentNodeDto(
+        Long id,
+        Integer departmentId,
+        String departmentName,
+        Boolean isActive
+) {
+    public static DepartmentNodeDto from(DepartmentNode n) {
+        return new DepartmentNodeDto(
+                n.getId(),
+                n.getDepartmentId(),
+                n.getDepartmentName(),
+                n.getIsActive()
+        );
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeDocumentDto.java
@@ -1,0 +1,276 @@
+package dk.ek.shift_happens.employee.mongo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * DTO for {@link EmployeeDocument}. Mirrors the document's nested structure
+ * with nested records so the denormalised employee read model can be
+ * transferred without exposing the persistence document itself.
+ *
+ * Security: loginPassword is write-only (accepted on create/update, never
+ * serialized back); the nested contract's salaryAmount is omitted entirely.
+ */
+public record EmployeeDocumentDto(
+        Integer employeeId,
+        String employeeNumber,
+        String firstName,
+        String lastName,
+        String email,
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String loginPassword,
+        String phoneNumber,
+        LocalDate hireDate,
+        String employmentStatus,
+        WorkLocation primaryWorkLocation,
+        String userRole,
+        List<EmployeeContract> employeeContracts,
+        List<JobRole> jobRoles,
+        List<LeaveRequest> leaveRequests,
+        List<LeaveLedgerEntry> leaveLedger
+) {
+    public static EmployeeDocumentDto from(EmployeeDocument e) {
+        return new EmployeeDocumentDto(
+                e.getEmployeeId(),
+                e.getEmployeeNumber(),
+                e.getFirstName(),
+                e.getLastName(),
+                e.getEmail(),
+                null,
+                e.getPhoneNumber(),
+                e.getHireDate(),
+                e.getEmploymentStatus(),
+                WorkLocation.from(e.getPrimaryWorkLocation()),
+                e.getUserRole(),
+                mapList(e.getEmployeeContracts(), EmployeeContract::from),
+                mapList(e.getJobRoles(), JobRole::from),
+                mapList(e.getLeaveRequests(), LeaveRequest::from),
+                mapList(e.getLeaveLedger(), LeaveLedgerEntry::from)
+        );
+    }
+
+    public EmployeeDocument toEntity() {
+        EmployeeDocument e = new EmployeeDocument();
+        e.setEmployeeId(employeeId);
+        e.setEmployeeNumber(employeeNumber);
+        e.setFirstName(firstName);
+        e.setLastName(lastName);
+        e.setEmail(email);
+        e.setLoginPassword(loginPassword);
+        e.setPhoneNumber(phoneNumber);
+        e.setHireDate(hireDate);
+        e.setEmploymentStatus(employmentStatus);
+        e.setPrimaryWorkLocation(primaryWorkLocation == null ? null : primaryWorkLocation.toEntity());
+        e.setUserRole(userRole);
+        e.setEmployeeContracts(mapList(employeeContracts, EmployeeContract::toEntity));
+        e.setJobRoles(mapList(jobRoles, JobRole::toEntity));
+        e.setLeaveRequests(mapList(leaveRequests, LeaveRequest::toEntity));
+        e.setLeaveLedger(mapList(leaveLedger, LeaveLedgerEntry::toEntity));
+        return e;
+    }
+
+    public record WorkLocation(Integer workLocationId, String locationName) {
+        static WorkLocation from(EmployeeDocument.WorkLocation s) {
+            return s == null ? null : new WorkLocation(s.getWorkLocationId(), s.getLocationName());
+        }
+
+        EmployeeDocument.WorkLocation toEntity() {
+            EmployeeDocument.WorkLocation s = new EmployeeDocument.WorkLocation();
+            s.setWorkLocationId(workLocationId);
+            s.setLocationName(locationName);
+            return s;
+        }
+    }
+
+    public record Department(Integer departmentId, String departmentName) {
+        static Department from(EmployeeDocument.Department s) {
+            return s == null ? null : new Department(s.getDepartmentId(), s.getDepartmentName());
+        }
+
+        EmployeeDocument.Department toEntity() {
+            EmployeeDocument.Department s = new EmployeeDocument.Department();
+            s.setDepartmentId(departmentId);
+            s.setDepartmentName(departmentName);
+            return s;
+        }
+    }
+
+    public record EmployeeContract(
+            Department department,
+            String contractType,
+            LocalDate startDate,
+            LocalDate endDate,
+            Integer weeklyHours,
+            Boolean isActive
+    ) {
+        // salaryAmount is intentionally omitted — it must not be exposed.
+        static EmployeeContract from(EmployeeDocument.EmployeeContract s) {
+            if (s == null) return null;
+            return new EmployeeContract(
+                    Department.from(s.getDepartment()),
+                    s.getContractType(),
+                    s.getStartDate(),
+                    s.getEndDate(),
+                    s.getWeeklyHours(),
+                    s.getIsActive()
+            );
+        }
+
+        EmployeeDocument.EmployeeContract toEntity() {
+            EmployeeDocument.EmployeeContract s = new EmployeeDocument.EmployeeContract();
+            s.setDepartment(department == null ? null : department.toEntity());
+            s.setContractType(contractType);
+            s.setStartDate(startDate);
+            s.setEndDate(endDate);
+            s.setWeeklyHours(weeklyHours);
+            // salaryAmount is not part of the DTO and is left null.
+            s.setIsActive(isActive);
+            return s;
+        }
+    }
+
+    public record JobRole(
+            String jobRoleId,
+            String roleName,
+            LocalDate assignedDate,
+            LocalDate expiryDate,
+            String proficiencyLevel
+    ) {
+        static JobRole from(EmployeeDocument.JobRole s) {
+            if (s == null) return null;
+            return new JobRole(
+                    s.getJobRoleId(),
+                    s.getRoleName(),
+                    s.getAssignedDate(),
+                    s.getExpiryDate(),
+                    s.getProficiencyLevel()
+            );
+        }
+
+        EmployeeDocument.JobRole toEntity() {
+            EmployeeDocument.JobRole s = new EmployeeDocument.JobRole();
+            s.setJobRoleId(jobRoleId);
+            s.setRoleName(roleName);
+            s.setAssignedDate(assignedDate);
+            s.setExpiryDate(expiryDate);
+            s.setProficiencyLevel(proficiencyLevel);
+            return s;
+        }
+    }
+
+    public record LeaveRequest(
+            Integer leaveTypeId,
+            LocalDate startDate,
+            LocalDate endDate,
+            String requestStatus,
+            String reason,
+            LocalDateTime requestedDatetime,
+            List<Approval> approvals
+    ) {
+        static LeaveRequest from(EmployeeDocument.LeaveRequest s) {
+            if (s == null) return null;
+            return new LeaveRequest(
+                    s.getLeaveTypeId(),
+                    s.getStartDate(),
+                    s.getEndDate(),
+                    s.getRequestStatus(),
+                    s.getReason(),
+                    s.getRequestedDatetime(),
+                    mapList(s.getApprovals(), Approval::from)
+            );
+        }
+
+        EmployeeDocument.LeaveRequest toEntity() {
+            EmployeeDocument.LeaveRequest s = new EmployeeDocument.LeaveRequest();
+            s.setLeaveTypeId(leaveTypeId);
+            s.setStartDate(startDate);
+            s.setEndDate(endDate);
+            s.setRequestStatus(requestStatus);
+            s.setReason(reason);
+            s.setRequestedDatetime(requestedDatetime);
+            s.setApprovals(mapList(approvals, Approval::toEntity));
+            return s;
+        }
+    }
+
+    public record Approval(
+            ApproverEmployee approverEmployee,
+            String decision,
+            String leaveComment,
+            LocalDateTime decisionDatetime
+    ) {
+        static Approval from(EmployeeDocument.Approval s) {
+            if (s == null) return null;
+            return new Approval(
+                    ApproverEmployee.from(s.getApproverEmployee()),
+                    s.getDecision(),
+                    s.getLeaveComment(),
+                    s.getDecisionDatetime()
+            );
+        }
+
+        EmployeeDocument.Approval toEntity() {
+            EmployeeDocument.Approval s = new EmployeeDocument.Approval();
+            s.setApproverEmployee(approverEmployee == null ? null : approverEmployee.toEntity());
+            s.setDecision(decision);
+            s.setLeaveComment(leaveComment);
+            s.setDecisionDatetime(decisionDatetime);
+            return s;
+        }
+    }
+
+    public record ApproverEmployee(Integer employeeId, String firstName, String lastName) {
+        static ApproverEmployee from(EmployeeDocument.ApproverEmployee s) {
+            return s == null ? null
+                    : new ApproverEmployee(s.getEmployeeId(), s.getFirstName(), s.getLastName());
+        }
+
+        EmployeeDocument.ApproverEmployee toEntity() {
+            EmployeeDocument.ApproverEmployee s = new EmployeeDocument.ApproverEmployee();
+            s.setEmployeeId(employeeId);
+            s.setFirstName(firstName);
+            s.setLastName(lastName);
+            return s;
+        }
+    }
+
+    public record LeaveLedgerEntry(
+            Integer leaveTypeId,
+            java.math.BigDecimal changeAmountDays,
+            String transactionType,
+            String referenceEntityType,
+            Integer referenceEntityId,
+            LocalDateTime transactionDatetime
+    ) {
+        static LeaveLedgerEntry from(EmployeeDocument.LeaveLedgerEntry s) {
+            if (s == null) return null;
+            return new LeaveLedgerEntry(
+                    s.getLeaveTypeId(),
+                    s.getChangeAmountDays(),
+                    s.getTransactionType(),
+                    s.getReferenceEntityType(),
+                    s.getReferenceEntityId(),
+                    s.getTransactionDatetime()
+            );
+        }
+
+        EmployeeDocument.LeaveLedgerEntry toEntity() {
+            EmployeeDocument.LeaveLedgerEntry s = new EmployeeDocument.LeaveLedgerEntry();
+            s.setLeaveTypeId(leaveTypeId);
+            s.setChangeAmountDays(changeAmountDays);
+            s.setTransactionType(transactionType);
+            s.setReferenceEntityType(referenceEntityType);
+            s.setReferenceEntityId(referenceEntityId);
+            s.setTransactionDatetime(transactionDatetime);
+            return s;
+        }
+    }
+
+    private static <S, T> List<T> mapList(List<S> src, Function<S, T> fn) {
+        return src == null ? null : src.stream().map(fn).toList();
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmployeeMongoController {
 
-    private final EmployeeMongoRepository employeeMongoRepository;
+    private final EmployeeMongoService employeeMongoService;
 
     @GetMapping
     public List<EmployeeDocumentDto> getAll() {
-        return employeeMongoRepository.findAll().stream().map(EmployeeDocumentDto::from).toList();
+        return employeeMongoService.findAll().stream().map(EmployeeDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public EmployeeDocumentDto getById(@PathVariable Integer id) {
-        return employeeMongoRepository.findById(id)
+        return employeeMongoService.findById(id)
                 .map(EmployeeDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public EmployeeDocumentDto create(@RequestBody EmployeeDocumentDto employee) {
-        return EmployeeDocumentDto.from(employeeMongoRepository.save(employee.toEntity()));
+        return EmployeeDocumentDto.from(employeeMongoService.create(employee.toEntity()));
     }
 
     @PutMapping("/{id}")
     public EmployeeDocumentDto update(@PathVariable Integer id, @RequestBody EmployeeDocumentDto employee) {
-        if (!employeeMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        EmployeeDocument entity = employee.toEntity();
-        entity.setEmployeeId(id);
-        return EmployeeDocumentDto.from(employeeMongoRepository.save(entity));
+        return employeeMongoService.update(id, employee.toEntity())
+                .map(EmployeeDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        if (!employeeMongoRepository.existsById(id)) {
+        if (!employeeMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        employeeMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
@@ -15,28 +15,30 @@ public class EmployeeMongoController {
     private final EmployeeMongoRepository employeeMongoRepository;
 
     @GetMapping
-    public List<EmployeeDocument> getAll() {
-        return employeeMongoRepository.findAll();
+    public List<EmployeeDocumentDto> getAll() {
+        return employeeMongoRepository.findAll().stream().map(EmployeeDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public EmployeeDocument getById(@PathVariable Integer id) {
+    public EmployeeDocumentDto getById(@PathVariable Integer id) {
         return employeeMongoRepository.findById(id)
+                .map(EmployeeDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public EmployeeDocument create(@RequestBody EmployeeDocument employee) {
-        return employeeMongoRepository.save(employee);
+    public EmployeeDocumentDto create(@RequestBody EmployeeDocumentDto employee) {
+        return EmployeeDocumentDto.from(employeeMongoRepository.save(employee.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public EmployeeDocument update(@PathVariable Integer id, @RequestBody EmployeeDocument employee) {
+    public EmployeeDocumentDto update(@PathVariable Integer id, @RequestBody EmployeeDocumentDto employee) {
         if (!employeeMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        employee.setEmployeeId(id);
-        return employeeMongoRepository.save(employee);
+        EmployeeDocument entity = employee.toEntity();
+        entity.setEmployeeId(id);
+        return EmployeeDocumentDto.from(employeeMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.employee.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeMongoService {
+
+    private final EmployeeMongoRepository employeeMongoRepository;
+
+    public List<EmployeeDocument> findAll() {
+        return employeeMongoRepository.findAll();
+    }
+
+    public Optional<EmployeeDocument> findById(Integer id) {
+        return employeeMongoRepository.findById(id);
+    }
+
+    public EmployeeDocument create(EmployeeDocument document) {
+        return employeeMongoRepository.save(document);
+    }
+
+    public Optional<EmployeeDocument> update(Integer id, EmployeeDocument document) {
+        if (!employeeMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setEmployeeId(id);
+        return Optional.of(employeeMongoRepository.save(document));
+    }
+
+    public boolean delete(Integer id) {
+        if (!employeeMongoRepository.existsById(id)) {
+            return false;
+        }
+        employeeMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
@@ -15,13 +15,14 @@ public class EmployeeNeo4jController {
     private final EmployeeNeo4jRepository employeeNeo4jRepository;
 
     @GetMapping
-    public List<EmployeeNode> getAll() {
-        return employeeNeo4jRepository.findAll();
+    public List<EmployeeNodeDto> getAll() {
+        return employeeNeo4jRepository.findAll().stream().map(EmployeeNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public EmployeeNode getById(@PathVariable Long id) {
+    public EmployeeNodeDto getById(@PathVariable Long id) {
         return employeeNeo4jRepository.findById(id)
+                .map(EmployeeNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmployeeNeo4jController {
 
-    private final EmployeeNeo4jRepository employeeNeo4jRepository;
+    private final EmployeeNeo4jService employeeNeo4jService;
 
     @GetMapping
     public List<EmployeeNodeDto> getAll() {
-        return employeeNeo4jRepository.findAll().stream().map(EmployeeNodeDto::from).toList();
+        return employeeNeo4jService.findAll().stream().map(EmployeeNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public EmployeeNodeDto getById(@PathVariable Long id) {
-        return employeeNeo4jRepository.findById(id)
+        return employeeNeo4jService.findById(id)
                 .map(EmployeeNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.employee.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeNeo4jService {
+
+    private final EmployeeNeo4jRepository employeeNeo4jRepository;
+
+    public List<EmployeeNode> findAll() {
+        return employeeNeo4jRepository.findAll();
+    }
+
+    public Optional<EmployeeNode> findById(Long id) {
+        return employeeNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNodeDto.java
@@ -1,0 +1,33 @@
+package dk.ek.shift_happens.employee.neo4j;
+
+import java.time.LocalDate;
+
+public record EmployeeNodeDto(
+        Long id,
+        Integer employeeId,
+        String employeeNumber,
+        String firstName,
+        String lastName,
+        String email,
+        String userRole,
+        String phoneNumber,
+        LocalDate hireDate,
+        String employmentStatus,
+        Integer primaryWorkLocationId
+) {
+    public static EmployeeNodeDto from(EmployeeNode n) {
+        return new EmployeeNodeDto(
+                n.getId(),
+                n.getEmployeeId(),
+                n.getEmployeeNumber(),
+                n.getFirstName(),
+                n.getLastName(),
+                n.getEmail(),
+                n.getUserRole(),
+                n.getPhoneNumber(),
+                n.getHireDate(),
+                n.getEmploymentStatus(),
+                n.getPrimaryWorkLocationId()
+        );
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractController.java
+++ b/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractController.java
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmployeeContractController {
 
-    private final EmployeeContractRepository employeeContractRepository;
+    private final EmployeeContractService employeeContractService;
     private final AuthHelper authHelper;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<EmployeeContractDto> getAll(Authentication auth) {
         List<EmployeeContract> contracts = authHelper.isEmployee(auth)
-                ? employeeContractRepository.findByEmployeeId(authHelper.currentEmployeeId(auth))
-                : employeeContractRepository.findAll();
+                ? employeeContractService.findByEmployeeId(authHelper.currentEmployeeId(auth))
+                : employeeContractService.findAll();
         return contracts.stream().map(EmployeeContractDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public EmployeeContractDto getById(@PathVariable Integer id, Authentication auth) {
-        EmployeeContract contract = employeeContractRepository.findById(id)
+        EmployeeContract contract = employeeContractService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
         if (authHelper.isEmployee(auth)
@@ -44,29 +44,21 @@ public class EmployeeContractController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public EmployeeContractDto create(@RequestBody EmployeeContractDto contract) {
-        return EmployeeContractDto.from(employeeContractRepository.save(contract.toEntity()));
+        return EmployeeContractDto.from(employeeContractService.create(contract.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public EmployeeContractDto update(@PathVariable Integer id, @RequestBody EmployeeContractDto details) {
-        EmployeeContract existing = employeeContractRepository.findById(id)
+        return employeeContractService.update(id, details.toEntity())
+                .map(EmployeeContractDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setEmployeeId(details.employeeId());
-        existing.setDepartmentId(details.departmentId());
-        existing.setContractType(details.contractType());
-        existing.setStartDate(details.startDate());
-        existing.setEndDate(details.endDate());
-        existing.setWeeklyHours(details.weeklyHours());
-        // salaryAmount is not part of the DTO and is left untouched on update.
-        existing.setIsActive(details.isActive());
-        return EmployeeContractDto.from(employeeContractRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        employeeContractRepository.deleteById(id);
+        employeeContractService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractService.java
+++ b/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractService.java
@@ -1,0 +1,48 @@
+package dk.ek.shift_happens.employeecontract;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeContractService {
+
+    private final EmployeeContractRepository employeeContractRepository;
+
+    public List<EmployeeContract> findAll() {
+        return employeeContractRepository.findAll();
+    }
+
+    public List<EmployeeContract> findByEmployeeId(Integer employeeId) {
+        return employeeContractRepository.findByEmployeeId(employeeId);
+    }
+
+    public Optional<EmployeeContract> findById(Integer id) {
+        return employeeContractRepository.findById(id);
+    }
+
+    public EmployeeContract create(EmployeeContract contract) {
+        return employeeContractRepository.save(contract);
+    }
+
+    public Optional<EmployeeContract> update(Integer id, EmployeeContract updates) {
+        return employeeContractRepository.findById(id).map(existing -> {
+            existing.setEmployeeId(updates.getEmployeeId());
+            existing.setDepartmentId(updates.getDepartmentId());
+            existing.setContractType(updates.getContractType());
+            existing.setStartDate(updates.getStartDate());
+            existing.setEndDate(updates.getEndDate());
+            existing.setWeeklyHours(updates.getWeeklyHours());
+            // salaryAmount is intentionally not updated — it is not part of the DTO.
+            existing.setIsActive(updates.getIsActive());
+            return employeeContractRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        employeeContractRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/JobRoleController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/JobRoleController.java
@@ -13,18 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JobRoleController {
 
-    private final JobRoleRepository jobRoleRepository;
+    private final JobRoleService jobRoleService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<JobRoleDto> getAll() {
-        return jobRoleRepository.findAll().stream().map(JobRoleDto::from).toList();
+        return jobRoleService.findAll().stream().map(JobRoleDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public JobRoleDto getById(@PathVariable Integer id) {
-        return jobRoleRepository.findById(id)
+        return jobRoleService.findById(id)
                 .map(JobRoleDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -33,24 +33,21 @@ public class JobRoleController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public JobRoleDto create(@RequestBody JobRoleDto jobRole) {
-        return JobRoleDto.from(jobRoleRepository.save(jobRole.toEntity()));
+        return JobRoleDto.from(jobRoleService.create(jobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public JobRoleDto update(@PathVariable Integer id, @RequestBody JobRoleDto details) {
-        JobRole existing = jobRoleRepository.findById(id)
+        return jobRoleService.update(id, details.toEntity())
+                .map(JobRoleDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setRoleName(details.roleName());
-        existing.setJobRoleDescription(details.jobRoleDescription());
-        existing.setIsCertificationRequired(details.isCertificationRequired());
-        return JobRoleDto.from(jobRoleRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        jobRoleRepository.deleteById(id);
+        jobRoleService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/jobrole/JobRoleService.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/JobRoleService.java
@@ -1,0 +1,39 @@
+package dk.ek.shift_happens.jobrole;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobRoleService {
+
+    private final JobRoleRepository jobRoleRepository;
+
+    public List<JobRole> findAll() {
+        return jobRoleRepository.findAll();
+    }
+
+    public Optional<JobRole> findById(Integer id) {
+        return jobRoleRepository.findById(id);
+    }
+
+    public JobRole create(JobRole jobRole) {
+        return jobRoleRepository.save(jobRole);
+    }
+
+    public Optional<JobRole> update(Integer id, JobRole updates) {
+        return jobRoleRepository.findById(id).map(existing -> {
+            existing.setRoleName(updates.getRoleName());
+            existing.setJobRoleDescription(updates.getJobRoleDescription());
+            existing.setIsCertificationRequired(updates.getIsCertificationRequired());
+            return jobRoleRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        jobRoleRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleDocumentDto.java
@@ -1,0 +1,29 @@
+package dk.ek.shift_happens.jobrole.mongo;
+
+public record JobRoleDocumentDto(
+        String id,
+        Integer jobRoleId,
+        String roleName,
+        String jobRoleDescription,
+        Boolean isCertificationRequired
+) {
+    public static JobRoleDocumentDto from(JobRoleDocument j) {
+        return new JobRoleDocumentDto(
+                j.getId(),
+                j.getJobRoleId(),
+                j.getRoleName(),
+                j.getJobRoleDescription(),
+                j.getIsCertificationRequired()
+        );
+    }
+
+    public JobRoleDocument toEntity() {
+        JobRoleDocument j = new JobRoleDocument();
+        j.setId(id);
+        j.setJobRoleId(jobRoleId);
+        j.setRoleName(roleName);
+        j.setJobRoleDescription(jobRoleDescription);
+        j.setIsCertificationRequired(isCertificationRequired);
+        return j;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JobRoleMongoController {
 
-    private final JobRoleMongoRepository jobRoleMongoRepository;
+    private final JobRoleMongoService jobRoleMongoService;
 
     @GetMapping
     public List<JobRoleDocumentDto> getAll() {
-        return jobRoleMongoRepository.findAll().stream().map(JobRoleDocumentDto::from).toList();
+        return jobRoleMongoService.findAll().stream().map(JobRoleDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public JobRoleDocumentDto getById(@PathVariable String id) {
-        return jobRoleMongoRepository.findById(id)
+        return jobRoleMongoService.findById(id)
                 .map(JobRoleDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public JobRoleDocumentDto create(@RequestBody JobRoleDocumentDto jobRole) {
-        return JobRoleDocumentDto.from(jobRoleMongoRepository.save(jobRole.toEntity()));
+        return JobRoleDocumentDto.from(jobRoleMongoService.create(jobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
     public JobRoleDocumentDto update(@PathVariable String id, @RequestBody JobRoleDocumentDto jobRole) {
-        if (!jobRoleMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        JobRoleDocument entity = jobRole.toEntity();
-        entity.setId(id);
-        return JobRoleDocumentDto.from(jobRoleMongoRepository.save(entity));
+        return jobRoleMongoService.update(id, jobRole.toEntity())
+                .map(JobRoleDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!jobRoleMongoRepository.existsById(id)) {
+        if (!jobRoleMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        jobRoleMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoController.java
@@ -15,28 +15,30 @@ public class JobRoleMongoController {
     private final JobRoleMongoRepository jobRoleMongoRepository;
 
     @GetMapping
-    public List<JobRoleDocument> getAll() {
-        return jobRoleMongoRepository.findAll();
+    public List<JobRoleDocumentDto> getAll() {
+        return jobRoleMongoRepository.findAll().stream().map(JobRoleDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public JobRoleDocument getById(@PathVariable String id) {
+    public JobRoleDocumentDto getById(@PathVariable String id) {
         return jobRoleMongoRepository.findById(id)
+                .map(JobRoleDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public JobRoleDocument create(@RequestBody JobRoleDocument jobRole) {
-        return jobRoleMongoRepository.save(jobRole);
+    public JobRoleDocumentDto create(@RequestBody JobRoleDocumentDto jobRole) {
+        return JobRoleDocumentDto.from(jobRoleMongoRepository.save(jobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public JobRoleDocument update(@PathVariable String id, @RequestBody JobRoleDocument jobRole) {
+    public JobRoleDocumentDto update(@PathVariable String id, @RequestBody JobRoleDocumentDto jobRole) {
         if (!jobRoleMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        jobRole.setId(id);
-        return jobRoleMongoRepository.save(jobRole);
+        JobRoleDocument entity = jobRole.toEntity();
+        entity.setId(id);
+        return JobRoleDocumentDto.from(jobRoleMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.jobrole.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobRoleMongoService {
+
+    private final JobRoleMongoRepository jobRoleMongoRepository;
+
+    public List<JobRoleDocument> findAll() {
+        return jobRoleMongoRepository.findAll();
+    }
+
+    public Optional<JobRoleDocument> findById(String id) {
+        return jobRoleMongoRepository.findById(id);
+    }
+
+    public JobRoleDocument create(JobRoleDocument document) {
+        return jobRoleMongoRepository.save(document);
+    }
+
+    public Optional<JobRoleDocument> update(String id, JobRoleDocument document) {
+        if (!jobRoleMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(jobRoleMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!jobRoleMongoRepository.existsById(id)) {
+            return false;
+        }
+        jobRoleMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jController.java
@@ -15,13 +15,14 @@ public class JobRoleNeo4jController {
     private final JobRoleNeo4jRepository jobRoleNeo4jRepository;
 
     @GetMapping
-    public List<JobRoleNode> getAll() {
-        return jobRoleNeo4jRepository.findAll();
+    public List<JobRoleNodeDto> getAll() {
+        return jobRoleNeo4jRepository.findAll().stream().map(JobRoleNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public JobRoleNode getById(@PathVariable Long id) {
+    public JobRoleNodeDto getById(@PathVariable Long id) {
         return jobRoleNeo4jRepository.findById(id)
+                .map(JobRoleNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JobRoleNeo4jController {
 
-    private final JobRoleNeo4jRepository jobRoleNeo4jRepository;
+    private final JobRoleNeo4jService jobRoleNeo4jService;
 
     @GetMapping
     public List<JobRoleNodeDto> getAll() {
-        return jobRoleNeo4jRepository.findAll().stream().map(JobRoleNodeDto::from).toList();
+        return jobRoleNeo4jService.findAll().stream().map(JobRoleNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public JobRoleNodeDto getById(@PathVariable Long id) {
-        return jobRoleNeo4jRepository.findById(id)
+        return jobRoleNeo4jService.findById(id)
                 .map(JobRoleNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.jobrole.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobRoleNeo4jService {
+
+    private final JobRoleNeo4jRepository jobRoleNeo4jRepository;
+
+    public List<JobRoleNode> findAll() {
+        return jobRoleNeo4jRepository.findAll();
+    }
+
+    public Optional<JobRoleNode> findById(Long id) {
+        return jobRoleNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNodeDto.java
@@ -1,0 +1,19 @@
+package dk.ek.shift_happens.jobrole.neo4j;
+
+public record JobRoleNodeDto(
+        Long id,
+        Integer jobRoleId,
+        String roleName,
+        String jobRoleDescription,
+        Boolean isCertificationRequired
+) {
+    public static JobRoleNodeDto from(JobRoleNode n) {
+        return new JobRoleNodeDto(
+                n.getId(),
+                n.getJobRoleId(),
+                n.getRoleName(),
+                n.getJobRoleDescription(),
+                n.getIsCertificationRequired()
+        );
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveApprovalNeo4jController {
 
-    private final LeaveApprovalNeo4jRepository leaveApprovalNeo4jRepository;
+    private final LeaveApprovalNeo4jService leaveApprovalNeo4jService;
 
     @GetMapping
     public List<LeaveApprovalNodeDto> getAll() {
-        return leaveApprovalNeo4jRepository.findAll().stream().map(LeaveApprovalNodeDto::from).toList();
+        return leaveApprovalNeo4jService.findAll().stream().map(LeaveApprovalNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveApprovalNodeDto getById(@PathVariable Long id) {
-        return leaveApprovalNeo4jRepository.findById(id)
+        return leaveApprovalNeo4jService.findById(id)
                 .map(LeaveApprovalNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveApprovalNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveApprovalNodeDto create(@RequestBody LeaveApprovalNodeDto node) {
-        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jRepository.save(node.toEntity()));
+        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveApprovalNodeDto update(@PathVariable Long id, @RequestBody LeaveApprovalNodeDto node) {
-        if (!leaveApprovalNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveApprovalNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jRepository.save(entity));
+        return leaveApprovalNeo4jService.update(id, node.toEntity())
+                .map(LeaveApprovalNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveApprovalNeo4jRepository.existsById(id)) {
+        if (!leaveApprovalNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveApprovalNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jController.java
@@ -15,29 +15,31 @@ public class LeaveApprovalNeo4jController {
     private final LeaveApprovalNeo4jRepository leaveApprovalNeo4jRepository;
 
     @GetMapping
-    public List<LeaveApprovalNode> getAll() {
-        return leaveApprovalNeo4jRepository.findAll();
+    public List<LeaveApprovalNodeDto> getAll() {
+        return leaveApprovalNeo4jRepository.findAll().stream().map(LeaveApprovalNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public LeaveApprovalNode getById(@PathVariable Long id) {
+    public LeaveApprovalNodeDto getById(@PathVariable Long id) {
         return leaveApprovalNeo4jRepository.findById(id)
+                .map(LeaveApprovalNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public LeaveApprovalNode create(@RequestBody LeaveApprovalNode node) {
-        return leaveApprovalNeo4jRepository.save(node);
+    public LeaveApprovalNodeDto create(@RequestBody LeaveApprovalNodeDto node) {
+        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jRepository.save(node.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public LeaveApprovalNode update(@PathVariable Long id, @RequestBody LeaveApprovalNode node) {
+    public LeaveApprovalNodeDto update(@PathVariable Long id, @RequestBody LeaveApprovalNodeDto node) {
         if (!leaveApprovalNeo4jRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        node.setId(id);
-        return leaveApprovalNeo4jRepository.save(node);
+        LeaveApprovalNode entity = node.toEntity();
+        entity.setId(id);
+        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaveapproval.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveApprovalNeo4jService {
+
+    private final LeaveApprovalNeo4jRepository leaveApprovalNeo4jRepository;
+
+    public List<LeaveApprovalNode> findAll() {
+        return leaveApprovalNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveApprovalNode> findById(Long id) {
+        return leaveApprovalNeo4jRepository.findById(id);
+    }
+
+    public LeaveApprovalNode create(LeaveApprovalNode node) {
+        return leaveApprovalNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveApprovalNode> update(Long id, LeaveApprovalNode node) {
+        if (!leaveApprovalNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveApprovalNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveApprovalNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveApprovalNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNodeDto.java
@@ -1,0 +1,37 @@
+package dk.ek.shift_happens.leaveapproval.neo4j;
+
+import java.time.LocalDateTime;
+
+public record LeaveApprovalNodeDto(
+        Long id,
+        Integer leaveApprovalId,
+        Integer leaveRequestId,
+        Integer approverEmployeeId,
+        String decision,
+        String leaveComment,
+        LocalDateTime decisionDatetime
+) {
+    public static LeaveApprovalNodeDto from(LeaveApprovalNode n) {
+        return new LeaveApprovalNodeDto(
+                n.getId(),
+                n.getLeaveApprovalId(),
+                n.getLeaveRequestId(),
+                n.getApproverEmployeeId(),
+                n.getDecision(),
+                n.getLeaveComment(),
+                n.getDecisionDatetime()
+        );
+    }
+
+    public LeaveApprovalNode toEntity() {
+        LeaveApprovalNode n = new LeaveApprovalNode();
+        n.setId(id);
+        n.setLeaveApprovalId(leaveApprovalId);
+        n.setLeaveRequestId(leaveRequestId);
+        n.setApproverEmployeeId(approverEmployeeId);
+        n.setDecision(decision);
+        n.setLeaveComment(leaveComment);
+        n.setDecisionDatetime(decisionDatetime);
+        return n;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerController.java
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveLedgerController {
 
-    private final LeaveLedgerRepository leaveLedgerRepository;
+    private final LeaveLedgerService leaveLedgerService;
     private final AuthHelper authHelper;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<LeaveLedgerDto> getAll(Authentication auth) {
         List<LeaveLedger> ledgers = authHelper.isEmployee(auth)
-                ? leaveLedgerRepository.findByEmployeeId(authHelper.currentEmployeeId(auth))
-                : leaveLedgerRepository.findAll();
+                ? leaveLedgerService.findByEmployeeId(authHelper.currentEmployeeId(auth))
+                : leaveLedgerService.findAll();
         return ledgers.stream().map(LeaveLedgerDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public LeaveLedgerDto getById(@PathVariable Integer id, Authentication auth) {
-        LeaveLedger ledger = leaveLedgerRepository.findById(id)
+        LeaveLedger ledger = leaveLedgerService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
         if (authHelper.isEmployee(auth)
@@ -44,28 +44,21 @@ public class LeaveLedgerController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveLedgerDto create(@RequestBody LeaveLedgerDto ledger) {
-        return LeaveLedgerDto.from(leaveLedgerRepository.save(ledger.toEntity()));
+        return LeaveLedgerDto.from(leaveLedgerService.create(ledger.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public LeaveLedgerDto update(@PathVariable Integer id, @RequestBody LeaveLedgerDto details) {
-        LeaveLedger existing = leaveLedgerRepository.findById(id)
+        return leaveLedgerService.update(id, details.toEntity())
+                .map(LeaveLedgerDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setEmployeeId(details.employeeId());
-        existing.setLeaveTypeId(details.leaveTypeId());
-        existing.setChangeAmountDays(details.changeAmountDays());
-        existing.setTransactionType(details.transactionType());
-        existing.setReferenceEntityType(details.referenceEntityType());
-        existing.setReferenceEntityId(details.referenceEntityId());
-        existing.setTransactionDatetime(details.transactionDatetime());
-        return LeaveLedgerDto.from(leaveLedgerRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        leaveLedgerRepository.deleteById(id);
+        leaveLedgerService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerService.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerService.java
@@ -1,0 +1,47 @@
+package dk.ek.shift_happens.leaveledger;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveLedgerService {
+
+    private final LeaveLedgerRepository leaveLedgerRepository;
+
+    public List<LeaveLedger> findAll() {
+        return leaveLedgerRepository.findAll();
+    }
+
+    public List<LeaveLedger> findByEmployeeId(Integer employeeId) {
+        return leaveLedgerRepository.findByEmployeeId(employeeId);
+    }
+
+    public Optional<LeaveLedger> findById(Integer id) {
+        return leaveLedgerRepository.findById(id);
+    }
+
+    public LeaveLedger create(LeaveLedger leaveLedger) {
+        return leaveLedgerRepository.save(leaveLedger);
+    }
+
+    public Optional<LeaveLedger> update(Integer id, LeaveLedger updates) {
+        return leaveLedgerRepository.findById(id).map(existing -> {
+            existing.setEmployeeId(updates.getEmployeeId());
+            existing.setLeaveTypeId(updates.getLeaveTypeId());
+            existing.setChangeAmountDays(updates.getChangeAmountDays());
+            existing.setTransactionType(updates.getTransactionType());
+            existing.setReferenceEntityType(updates.getReferenceEntityType());
+            existing.setReferenceEntityId(updates.getReferenceEntityId());
+            existing.setTransactionDatetime(updates.getTransactionDatetime());
+            return leaveLedgerRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        leaveLedgerRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveLedgerNeo4jController {
 
-    private final LeaveLedgerNeo4jRepository leaveLedgerNeo4jRepository;
+    private final LeaveLedgerNeo4jService leaveLedgerNeo4jService;
 
     @GetMapping
     public List<LeaveLedgerNodeDto> getAll() {
-        return leaveLedgerNeo4jRepository.findAll().stream().map(LeaveLedgerNodeDto::from).toList();
+        return leaveLedgerNeo4jService.findAll().stream().map(LeaveLedgerNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveLedgerNodeDto getById(@PathVariable Long id) {
-        return leaveLedgerNeo4jRepository.findById(id)
+        return leaveLedgerNeo4jService.findById(id)
                 .map(LeaveLedgerNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveLedgerNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveLedgerNodeDto create(@RequestBody LeaveLedgerNodeDto node) {
-        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jRepository.save(node.toEntity()));
+        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveLedgerNodeDto update(@PathVariable Long id, @RequestBody LeaveLedgerNodeDto node) {
-        if (!leaveLedgerNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveLedgerNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jRepository.save(entity));
+        return leaveLedgerNeo4jService.update(id, node.toEntity())
+                .map(LeaveLedgerNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveLedgerNeo4jRepository.existsById(id)) {
+        if (!leaveLedgerNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveLedgerNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jController.java
@@ -15,29 +15,31 @@ public class LeaveLedgerNeo4jController {
     private final LeaveLedgerNeo4jRepository leaveLedgerNeo4jRepository;
 
     @GetMapping
-    public List<LeaveLedgerNode> getAll() {
-        return leaveLedgerNeo4jRepository.findAll();
+    public List<LeaveLedgerNodeDto> getAll() {
+        return leaveLedgerNeo4jRepository.findAll().stream().map(LeaveLedgerNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public LeaveLedgerNode getById(@PathVariable Long id) {
+    public LeaveLedgerNodeDto getById(@PathVariable Long id) {
         return leaveLedgerNeo4jRepository.findById(id)
+                .map(LeaveLedgerNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public LeaveLedgerNode create(@RequestBody LeaveLedgerNode node) {
-        return leaveLedgerNeo4jRepository.save(node);
+    public LeaveLedgerNodeDto create(@RequestBody LeaveLedgerNodeDto node) {
+        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jRepository.save(node.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public LeaveLedgerNode update(@PathVariable Long id, @RequestBody LeaveLedgerNode node) {
+    public LeaveLedgerNodeDto update(@PathVariable Long id, @RequestBody LeaveLedgerNodeDto node) {
         if (!leaveLedgerNeo4jRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        node.setId(id);
-        return leaveLedgerNeo4jRepository.save(node);
+        LeaveLedgerNode entity = node.toEntity();
+        entity.setId(id);
+        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaveledger.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveLedgerNeo4jService {
+
+    private final LeaveLedgerNeo4jRepository leaveLedgerNeo4jRepository;
+
+    public List<LeaveLedgerNode> findAll() {
+        return leaveLedgerNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveLedgerNode> findById(Long id) {
+        return leaveLedgerNeo4jRepository.findById(id);
+    }
+
+    public LeaveLedgerNode create(LeaveLedgerNode node) {
+        return leaveLedgerNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveLedgerNode> update(Long id, LeaveLedgerNode node) {
+        if (!leaveLedgerNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveLedgerNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveLedgerNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveLedgerNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNodeDto.java
@@ -1,0 +1,44 @@
+package dk.ek.shift_happens.leaveledger.neo4j;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record LeaveLedgerNodeDto(
+        Long id,
+        Integer leaveLedgerId,
+        Integer employeeId,
+        Integer leaveTypeId,
+        BigDecimal changeAmountDays,
+        String transactionType,
+        String referenceEntityType,
+        Integer referenceEntityId,
+        LocalDateTime transactionDatetime
+) {
+    public static LeaveLedgerNodeDto from(LeaveLedgerNode n) {
+        return new LeaveLedgerNodeDto(
+                n.getId(),
+                n.getLeaveLedgerId(),
+                n.getEmployeeId(),
+                n.getLeaveTypeId(),
+                n.getChangeAmountDays(),
+                n.getTransactionType(),
+                n.getReferenceEntityType(),
+                n.getReferenceEntityId(),
+                n.getTransactionDatetime()
+        );
+    }
+
+    public LeaveLedgerNode toEntity() {
+        LeaveLedgerNode n = new LeaveLedgerNode();
+        n.setId(id);
+        n.setLeaveLedgerId(leaveLedgerId);
+        n.setEmployeeId(employeeId);
+        n.setLeaveTypeId(leaveTypeId);
+        n.setChangeAmountDays(changeAmountDays);
+        n.setTransactionType(transactionType);
+        n.setReferenceEntityType(referenceEntityType);
+        n.setReferenceEntityId(referenceEntityId);
+        n.setTransactionDatetime(transactionDatetime);
+        return n;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveDocumentDto.java
@@ -1,0 +1,104 @@
+package dk.ek.shift_happens.leaverequest.mongo;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * DTO for {@link LeaveDocument}. Mirrors the document's nested structure with
+ * nested records so the denormalised leave read model can be transferred
+ * without exposing the persistence document itself.
+ */
+public record LeaveDocumentDto(
+        String id,
+        Integer employeeId,
+        List<LeaveRequestRef> requests
+) {
+    public static LeaveDocumentDto from(LeaveDocument d) {
+        return new LeaveDocumentDto(
+                d.getId(),
+                d.getEmployeeId(),
+                mapList(d.getRequests(), LeaveRequestRef::from)
+        );
+    }
+
+    public LeaveDocument toEntity() {
+        LeaveDocument d = new LeaveDocument();
+        d.setId(id);
+        d.setEmployeeId(employeeId);
+        d.setRequests(mapList(requests, LeaveRequestRef::toEntity));
+        return d;
+    }
+
+    public record LeaveRequestRef(
+            Integer leaveRequestId,
+            Integer leaveTypeId,
+            String leaveTypeName,
+            LocalDate startDate,
+            LocalDate endDate,
+            String requestStatus,
+            String reason,
+            LocalDateTime requestedAt,
+            List<ApprovalRef> approvals
+    ) {
+        static LeaveRequestRef from(LeaveDocument.LeaveRequestRef r) {
+            if (r == null) return null;
+            return new LeaveRequestRef(
+                    r.getLeaveRequestId(),
+                    r.getLeaveTypeId(),
+                    r.getLeaveTypeName(),
+                    r.getStartDate(),
+                    r.getEndDate(),
+                    r.getRequestStatus(),
+                    r.getReason(),
+                    r.getRequestedAt(),
+                    mapList(r.getApprovals(), ApprovalRef::from)
+            );
+        }
+
+        LeaveDocument.LeaveRequestRef toEntity() {
+            LeaveDocument.LeaveRequestRef r = new LeaveDocument.LeaveRequestRef();
+            r.setLeaveRequestId(leaveRequestId);
+            r.setLeaveTypeId(leaveTypeId);
+            r.setLeaveTypeName(leaveTypeName);
+            r.setStartDate(startDate);
+            r.setEndDate(endDate);
+            r.setRequestStatus(requestStatus);
+            r.setReason(reason);
+            r.setRequestedAt(requestedAt);
+            r.setApprovals(mapList(approvals, ApprovalRef::toEntity));
+            return r;
+        }
+    }
+
+    public record ApprovalRef(
+            Integer approverEmployeeId,
+            String decision,
+            String comment,
+            LocalDateTime decidedAt
+    ) {
+        static ApprovalRef from(LeaveDocument.ApprovalRef a) {
+            if (a == null) return null;
+            return new ApprovalRef(
+                    a.getApproverEmployeeId(),
+                    a.getDecision(),
+                    a.getComment(),
+                    a.getDecidedAt()
+            );
+        }
+
+        LeaveDocument.ApprovalRef toEntity() {
+            LeaveDocument.ApprovalRef a = new LeaveDocument.ApprovalRef();
+            a.setApproverEmployeeId(approverEmployeeId);
+            a.setDecision(decision);
+            a.setComment(comment);
+            a.setDecidedAt(decidedAt);
+            return a;
+        }
+    }
+
+    private static <S, T> List<T> mapList(List<S> src, Function<S, T> fn) {
+        return src == null ? null : src.stream().map(fn).toList();
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoController.java
@@ -15,28 +15,30 @@ public class LeaveMongoController {
     private final LeaveMongoRepository leaveMongoRepository;
 
     @GetMapping
-    public List<LeaveDocument> getAll() {
-        return leaveMongoRepository.findAll();
+    public List<LeaveDocumentDto> getAll() {
+        return leaveMongoRepository.findAll().stream().map(LeaveDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public LeaveDocument getById(@PathVariable String id) {
+    public LeaveDocumentDto getById(@PathVariable String id) {
         return leaveMongoRepository.findById(id)
+                .map(LeaveDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public LeaveDocument create(@RequestBody LeaveDocument leave) {
-        return leaveMongoRepository.save(leave);
+    public LeaveDocumentDto create(@RequestBody LeaveDocumentDto leave) {
+        return LeaveDocumentDto.from(leaveMongoRepository.save(leave.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public LeaveDocument update(@PathVariable String id, @RequestBody LeaveDocument leave) {
+    public LeaveDocumentDto update(@PathVariable String id, @RequestBody LeaveDocumentDto leave) {
         if (!leaveMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leave.setId(id);
-        return leaveMongoRepository.save(leave);
+        LeaveDocument entity = leave.toEntity();
+        entity.setId(id);
+        return LeaveDocumentDto.from(leaveMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveMongoController {
 
-    private final LeaveMongoRepository leaveMongoRepository;
+    private final LeaveMongoService leaveMongoService;
 
     @GetMapping
     public List<LeaveDocumentDto> getAll() {
-        return leaveMongoRepository.findAll().stream().map(LeaveDocumentDto::from).toList();
+        return leaveMongoService.findAll().stream().map(LeaveDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveDocumentDto getById(@PathVariable String id) {
-        return leaveMongoRepository.findById(id)
+        return leaveMongoService.findById(id)
                 .map(LeaveDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public LeaveDocumentDto create(@RequestBody LeaveDocumentDto leave) {
-        return LeaveDocumentDto.from(leaveMongoRepository.save(leave.toEntity()));
+        return LeaveDocumentDto.from(leaveMongoService.create(leave.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveDocumentDto update(@PathVariable String id, @RequestBody LeaveDocumentDto leave) {
-        if (!leaveMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveDocument entity = leave.toEntity();
-        entity.setId(id);
-        return LeaveDocumentDto.from(leaveMongoRepository.save(entity));
+        return leaveMongoService.update(id, leave.toEntity())
+                .map(LeaveDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!leaveMongoRepository.existsById(id)) {
+        if (!leaveMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaverequest.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveMongoService {
+
+    private final LeaveMongoRepository leaveMongoRepository;
+
+    public List<LeaveDocument> findAll() {
+        return leaveMongoRepository.findAll();
+    }
+
+    public Optional<LeaveDocument> findById(String id) {
+        return leaveMongoRepository.findById(id);
+    }
+
+    public LeaveDocument create(LeaveDocument document) {
+        return leaveMongoRepository.save(document);
+    }
+
+    public Optional<LeaveDocument> update(String id, LeaveDocument document) {
+        if (!leaveMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(leaveMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!leaveMongoRepository.existsById(id)) {
+            return false;
+        }
+        leaveMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveRequestNeo4jController {
 
-    private final LeaveRequestNeo4jRepository leaveRequestNeo4jRepository;
+    private final LeaveRequestNeo4jService leaveRequestNeo4jService;
 
     @GetMapping
     public List<LeaveRequestNodeDto> getAll() {
-        return leaveRequestNeo4jRepository.findAll().stream().map(LeaveRequestNodeDto::from).toList();
+        return leaveRequestNeo4jService.findAll().stream().map(LeaveRequestNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveRequestNodeDto getById(@PathVariable Long id) {
-        return leaveRequestNeo4jRepository.findById(id)
+        return leaveRequestNeo4jService.findById(id)
                 .map(LeaveRequestNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveRequestNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveRequestNodeDto create(@RequestBody LeaveRequestNodeDto node) {
-        return LeaveRequestNodeDto.from(leaveRequestNeo4jRepository.save(node.toEntity()));
+        return LeaveRequestNodeDto.from(leaveRequestNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveRequestNodeDto update(@PathVariable Long id, @RequestBody LeaveRequestNodeDto node) {
-        if (!leaveRequestNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveRequestNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveRequestNodeDto.from(leaveRequestNeo4jRepository.save(entity));
+        return leaveRequestNeo4jService.update(id, node.toEntity())
+                .map(LeaveRequestNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveRequestNeo4jRepository.existsById(id)) {
+        if (!leaveRequestNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveRequestNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jController.java
@@ -15,29 +15,31 @@ public class LeaveRequestNeo4jController {
     private final LeaveRequestNeo4jRepository leaveRequestNeo4jRepository;
 
     @GetMapping
-    public List<LeaveRequestNode> getAll() {
-        return leaveRequestNeo4jRepository.findAll();
+    public List<LeaveRequestNodeDto> getAll() {
+        return leaveRequestNeo4jRepository.findAll().stream().map(LeaveRequestNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public LeaveRequestNode getById(@PathVariable Long id) {
+    public LeaveRequestNodeDto getById(@PathVariable Long id) {
         return leaveRequestNeo4jRepository.findById(id)
+                .map(LeaveRequestNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public LeaveRequestNode create(@RequestBody LeaveRequestNode node) {
-        return leaveRequestNeo4jRepository.save(node);
+    public LeaveRequestNodeDto create(@RequestBody LeaveRequestNodeDto node) {
+        return LeaveRequestNodeDto.from(leaveRequestNeo4jRepository.save(node.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public LeaveRequestNode update(@PathVariable Long id, @RequestBody LeaveRequestNode node) {
+    public LeaveRequestNodeDto update(@PathVariable Long id, @RequestBody LeaveRequestNodeDto node) {
         if (!leaveRequestNeo4jRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        node.setId(id);
-        return leaveRequestNeo4jRepository.save(node);
+        LeaveRequestNode entity = node.toEntity();
+        entity.setId(id);
+        return LeaveRequestNodeDto.from(leaveRequestNeo4jRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaverequest.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveRequestNeo4jService {
+
+    private final LeaveRequestNeo4jRepository leaveRequestNeo4jRepository;
+
+    public List<LeaveRequestNode> findAll() {
+        return leaveRequestNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveRequestNode> findById(Long id) {
+        return leaveRequestNeo4jRepository.findById(id);
+    }
+
+    public LeaveRequestNode create(LeaveRequestNode node) {
+        return leaveRequestNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveRequestNode> update(Long id, LeaveRequestNode node) {
+        if (!leaveRequestNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveRequestNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveRequestNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveRequestNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNodeDto.java
@@ -1,0 +1,44 @@
+package dk.ek.shift_happens.leaverequest.neo4j;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record LeaveRequestNodeDto(
+        Long id,
+        Integer leaveRequestId,
+        Integer employeeId,
+        Integer leaveTypeId,
+        LocalDate startDate,
+        LocalDate endDate,
+        String requestStatus,
+        String reason,
+        LocalDateTime requestedDatetime
+) {
+    public static LeaveRequestNodeDto from(LeaveRequestNode n) {
+        return new LeaveRequestNodeDto(
+                n.getId(),
+                n.getLeaveRequestId(),
+                n.getEmployeeId(),
+                n.getLeaveTypeId(),
+                n.getStartDate(),
+                n.getEndDate(),
+                n.getRequestStatus(),
+                n.getReason(),
+                n.getRequestedDatetime()
+        );
+    }
+
+    public LeaveRequestNode toEntity() {
+        LeaveRequestNode n = new LeaveRequestNode();
+        n.setId(id);
+        n.setLeaveRequestId(leaveRequestId);
+        n.setEmployeeId(employeeId);
+        n.setLeaveTypeId(leaveTypeId);
+        n.setStartDate(startDate);
+        n.setEndDate(endDate);
+        n.setRequestStatus(requestStatus);
+        n.setReason(reason);
+        n.setRequestedDatetime(requestedDatetime);
+        return n;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeController.java
@@ -13,18 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveTypeController {
 
-    private final LeaveTypeRepository leaveTypeRepository;
+    private final LeaveTypeService leaveTypeService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<LeaveTypeDto> getAll() {
-        return leaveTypeRepository.findAll().stream().map(LeaveTypeDto::from).toList();
+        return leaveTypeService.findAll().stream().map(LeaveTypeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public LeaveTypeDto getById(@PathVariable Integer id) {
-        return leaveTypeRepository.findById(id)
+        return leaveTypeService.findById(id)
                 .map(LeaveTypeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -33,25 +33,21 @@ public class LeaveTypeController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveTypeDto create(@RequestBody LeaveTypeDto leaveType) {
-        return LeaveTypeDto.from(leaveTypeRepository.save(leaveType.toEntity()));
+        return LeaveTypeDto.from(leaveTypeService.create(leaveType.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public LeaveTypeDto update(@PathVariable Integer id, @RequestBody LeaveTypeDto details) {
-        LeaveType existing = leaveTypeRepository.findById(id)
+        return leaveTypeService.update(id, details.toEntity())
+                .map(LeaveTypeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setLeaveTypeName(details.leaveTypeName());
-        existing.setLeaveTypeDescription(details.leaveTypeDescription());
-        existing.setRequiresApproval(details.requiresApproval());
-        existing.setIsPaidLeave(details.isPaidLeave());
-        return LeaveTypeDto.from(leaveTypeRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        leaveTypeRepository.deleteById(id);
+        leaveTypeService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeService.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeService.java
@@ -1,0 +1,40 @@
+package dk.ek.shift_happens.leavetype;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveTypeService {
+
+    private final LeaveTypeRepository leaveTypeRepository;
+
+    public List<LeaveType> findAll() {
+        return leaveTypeRepository.findAll();
+    }
+
+    public Optional<LeaveType> findById(Integer id) {
+        return leaveTypeRepository.findById(id);
+    }
+
+    public LeaveType create(LeaveType leaveType) {
+        return leaveTypeRepository.save(leaveType);
+    }
+
+    public Optional<LeaveType> update(Integer id, LeaveType updates) {
+        return leaveTypeRepository.findById(id).map(existing -> {
+            existing.setLeaveTypeName(updates.getLeaveTypeName());
+            existing.setLeaveTypeDescription(updates.getLeaveTypeDescription());
+            existing.setRequiresApproval(updates.getRequiresApproval());
+            existing.setIsPaidLeave(updates.getIsPaidLeave());
+            return leaveTypeRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        leaveTypeRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeDocumentDto.java
@@ -1,0 +1,32 @@
+package dk.ek.shift_happens.leavetype.mongo;
+
+public record LeaveTypeDocumentDto(
+        String id,
+        Integer leaveTypeId,
+        String leaveTypeName,
+        String leaveTypeDescription,
+        Boolean requiresApproval,
+        Boolean isPaidLeave
+) {
+    public static LeaveTypeDocumentDto from(LeaveTypeDocument l) {
+        return new LeaveTypeDocumentDto(
+                l.getId(),
+                l.getLeaveTypeId(),
+                l.getLeaveTypeName(),
+                l.getLeaveTypeDescription(),
+                l.getRequiresApproval(),
+                l.getIsPaidLeave()
+        );
+    }
+
+    public LeaveTypeDocument toEntity() {
+        LeaveTypeDocument l = new LeaveTypeDocument();
+        l.setId(id);
+        l.setLeaveTypeId(leaveTypeId);
+        l.setLeaveTypeName(leaveTypeName);
+        l.setLeaveTypeDescription(leaveTypeDescription);
+        l.setRequiresApproval(requiresApproval);
+        l.setIsPaidLeave(isPaidLeave);
+        return l;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveTypeMongoController {
 
-    private final LeaveTypeMongoRepository leaveTypeMongoRepository;
+    private final LeaveTypeMongoService leaveTypeMongoService;
 
     @GetMapping
     public List<LeaveTypeDocumentDto> getAll() {
-        return leaveTypeMongoRepository.findAll().stream().map(LeaveTypeDocumentDto::from).toList();
+        return leaveTypeMongoService.findAll().stream().map(LeaveTypeDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveTypeDocumentDto getById(@PathVariable String id) {
-        return leaveTypeMongoRepository.findById(id)
+        return leaveTypeMongoService.findById(id)
                 .map(LeaveTypeDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public LeaveTypeDocumentDto create(@RequestBody LeaveTypeDocumentDto leaveType) {
-        return LeaveTypeDocumentDto.from(leaveTypeMongoRepository.save(leaveType.toEntity()));
+        return LeaveTypeDocumentDto.from(leaveTypeMongoService.create(leaveType.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveTypeDocumentDto update(@PathVariable String id, @RequestBody LeaveTypeDocumentDto leaveType) {
-        if (!leaveTypeMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveTypeDocument entity = leaveType.toEntity();
-        entity.setId(id);
-        return LeaveTypeDocumentDto.from(leaveTypeMongoRepository.save(entity));
+        return leaveTypeMongoService.update(id, leaveType.toEntity())
+                .map(LeaveTypeDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!leaveTypeMongoRepository.existsById(id)) {
+        if (!leaveTypeMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveTypeMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoController.java
@@ -15,28 +15,30 @@ public class LeaveTypeMongoController {
     private final LeaveTypeMongoRepository leaveTypeMongoRepository;
 
     @GetMapping
-    public List<LeaveTypeDocument> getAll() {
-        return leaveTypeMongoRepository.findAll();
+    public List<LeaveTypeDocumentDto> getAll() {
+        return leaveTypeMongoRepository.findAll().stream().map(LeaveTypeDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public LeaveTypeDocument getById(@PathVariable String id) {
+    public LeaveTypeDocumentDto getById(@PathVariable String id) {
         return leaveTypeMongoRepository.findById(id)
+                .map(LeaveTypeDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public LeaveTypeDocument create(@RequestBody LeaveTypeDocument leaveType) {
-        return leaveTypeMongoRepository.save(leaveType);
+    public LeaveTypeDocumentDto create(@RequestBody LeaveTypeDocumentDto leaveType) {
+        return LeaveTypeDocumentDto.from(leaveTypeMongoRepository.save(leaveType.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public LeaveTypeDocument update(@PathVariable String id, @RequestBody LeaveTypeDocument leaveType) {
+    public LeaveTypeDocumentDto update(@PathVariable String id, @RequestBody LeaveTypeDocumentDto leaveType) {
         if (!leaveTypeMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveType.setId(id);
-        return leaveTypeMongoRepository.save(leaveType);
+        LeaveTypeDocument entity = leaveType.toEntity();
+        entity.setId(id);
+        return LeaveTypeDocumentDto.from(leaveTypeMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leavetype.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveTypeMongoService {
+
+    private final LeaveTypeMongoRepository leaveTypeMongoRepository;
+
+    public List<LeaveTypeDocument> findAll() {
+        return leaveTypeMongoRepository.findAll();
+    }
+
+    public Optional<LeaveTypeDocument> findById(String id) {
+        return leaveTypeMongoRepository.findById(id);
+    }
+
+    public LeaveTypeDocument create(LeaveTypeDocument document) {
+        return leaveTypeMongoRepository.save(document);
+    }
+
+    public Optional<LeaveTypeDocument> update(String id, LeaveTypeDocument document) {
+        if (!leaveTypeMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(leaveTypeMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!leaveTypeMongoRepository.existsById(id)) {
+            return false;
+        }
+        leaveTypeMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jController.java
@@ -15,29 +15,31 @@ public class LeaveTypeNeo4jController {
     private final LeaveTypeNeo4jRepository leaveTypeNeo4jRepository;
 
     @GetMapping
-    public List<LeaveTypeNode> getAll() {
-        return leaveTypeNeo4jRepository.findAll();
+    public List<LeaveTypeNodeDto> getAll() {
+        return leaveTypeNeo4jRepository.findAll().stream().map(LeaveTypeNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public LeaveTypeNode getById(@PathVariable Long id) {
+    public LeaveTypeNodeDto getById(@PathVariable Long id) {
         return leaveTypeNeo4jRepository.findById(id)
+                .map(LeaveTypeNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public LeaveTypeNode create(@RequestBody LeaveTypeNode node) {
-        return leaveTypeNeo4jRepository.save(node);
+    public LeaveTypeNodeDto create(@RequestBody LeaveTypeNodeDto node) {
+        return LeaveTypeNodeDto.from(leaveTypeNeo4jRepository.save(node.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public LeaveTypeNode update(@PathVariable Long id, @RequestBody LeaveTypeNode node) {
+    public LeaveTypeNodeDto update(@PathVariable Long id, @RequestBody LeaveTypeNodeDto node) {
         if (!leaveTypeNeo4jRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        node.setId(id);
-        return leaveTypeNeo4jRepository.save(node);
+        LeaveTypeNode entity = node.toEntity();
+        entity.setId(id);
+        return LeaveTypeNodeDto.from(leaveTypeNeo4jRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveTypeNeo4jController {
 
-    private final LeaveTypeNeo4jRepository leaveTypeNeo4jRepository;
+    private final LeaveTypeNeo4jService leaveTypeNeo4jService;
 
     @GetMapping
     public List<LeaveTypeNodeDto> getAll() {
-        return leaveTypeNeo4jRepository.findAll().stream().map(LeaveTypeNodeDto::from).toList();
+        return leaveTypeNeo4jService.findAll().stream().map(LeaveTypeNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveTypeNodeDto getById(@PathVariable Long id) {
-        return leaveTypeNeo4jRepository.findById(id)
+        return leaveTypeNeo4jService.findById(id)
                 .map(LeaveTypeNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveTypeNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveTypeNodeDto create(@RequestBody LeaveTypeNodeDto node) {
-        return LeaveTypeNodeDto.from(leaveTypeNeo4jRepository.save(node.toEntity()));
+        return LeaveTypeNodeDto.from(leaveTypeNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveTypeNodeDto update(@PathVariable Long id, @RequestBody LeaveTypeNodeDto node) {
-        if (!leaveTypeNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveTypeNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveTypeNodeDto.from(leaveTypeNeo4jRepository.save(entity));
+        return leaveTypeNeo4jService.update(id, node.toEntity())
+                .map(LeaveTypeNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveTypeNeo4jRepository.existsById(id)) {
+        if (!leaveTypeNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveTypeNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leavetype.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveTypeNeo4jService {
+
+    private final LeaveTypeNeo4jRepository leaveTypeNeo4jRepository;
+
+    public List<LeaveTypeNode> findAll() {
+        return leaveTypeNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveTypeNode> findById(Long id) {
+        return leaveTypeNeo4jRepository.findById(id);
+    }
+
+    public LeaveTypeNode create(LeaveTypeNode node) {
+        return leaveTypeNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveTypeNode> update(Long id, LeaveTypeNode node) {
+        if (!leaveTypeNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveTypeNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveTypeNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveTypeNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNodeDto.java
@@ -1,0 +1,32 @@
+package dk.ek.shift_happens.leavetype.neo4j;
+
+public record LeaveTypeNodeDto(
+        Long id,
+        Integer leaveTypeId,
+        String leaveTypeName,
+        String leaveTypeDescription,
+        Boolean requiresApproval,
+        Boolean isPaidLeave
+) {
+    public static LeaveTypeNodeDto from(LeaveTypeNode n) {
+        return new LeaveTypeNodeDto(
+                n.getId(),
+                n.getLeaveTypeId(),
+                n.getLeaveTypeName(),
+                n.getLeaveTypeDescription(),
+                n.getRequiresApproval(),
+                n.getIsPaidLeave()
+        );
+    }
+
+    public LeaveTypeNode toEntity() {
+        LeaveTypeNode n = new LeaveTypeNode();
+        n.setId(id);
+        n.setLeaveTypeId(leaveTypeId);
+        n.setLeaveTypeName(leaveTypeName);
+        n.setLeaveTypeDescription(leaveTypeDescription);
+        n.setRequiresApproval(requiresApproval);
+        n.setIsPaidLeave(isPaidLeave);
+        return n;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/ShiftController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/ShiftController.java
@@ -12,42 +12,37 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftController {
 
-    private final ShiftRepository shiftRepository;
+    private final ShiftService shiftService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<ShiftDto> getShifts() {
-        return this.shiftRepository.findAll().stream().map(ShiftDto::from).toList();
+        return this.shiftService.findAll().stream().map(ShiftDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public Optional<ShiftDto> getShiftById(@PathVariable Integer id) {
-        return this.shiftRepository.findById(id).map(ShiftDto::from);
+        return this.shiftService.findById(id).map(ShiftDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftDto createShift(@RequestBody ShiftDto shift) {
-        return ShiftDto.from(this.shiftRepository.save(shift.toEntity()));
+        return ShiftDto.from(this.shiftService.create(shift.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftDto updateShift(@PathVariable Integer id, @RequestBody ShiftDto shiftDetails) {
-        Shift shift = this.shiftRepository.findById(id).orElseThrow();
-        shift.setDepartmentId(shiftDetails.departmentId());
-        shift.setWorkLocationId(shiftDetails.workLocationId());
-        shift.setShiftName(shiftDetails.shiftName());
-        shift.setStartDatetime(shiftDetails.startDatetime());
-        shift.setEndDatetime(shiftDetails.endDatetime());
-        shift.setShiftStatus(shiftDetails.shiftStatus());
-        return ShiftDto.from(this.shiftRepository.save(shift));
+        return this.shiftService.update(id, shiftDetails.toEntity())
+                .map(ShiftDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShift(@PathVariable Integer id) {
-        this.shiftRepository.deleteById(id);
+        this.shiftService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shift/ShiftService.java
+++ b/src/main/java/dk/ek/shift_happens/shift/ShiftService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.shift;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftService {
+
+    private final ShiftRepository shiftRepository;
+
+    public List<Shift> findAll() {
+        return shiftRepository.findAll();
+    }
+
+    public Optional<Shift> findById(Integer id) {
+        return shiftRepository.findById(id);
+    }
+
+    public Shift create(Shift shift) {
+        return shiftRepository.save(shift);
+    }
+
+    public Optional<Shift> update(Integer id, Shift updates) {
+        return shiftRepository.findById(id).map(existing -> {
+            existing.setDepartmentId(updates.getDepartmentId());
+            existing.setWorkLocationId(updates.getWorkLocationId());
+            existing.setShiftName(updates.getShiftName());
+            existing.setStartDatetime(updates.getStartDatetime());
+            existing.setEndDatetime(updates.getEndDatetime());
+            existing.setShiftStatus(updates.getShiftStatus());
+            return shiftRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftDocumentDto.java
@@ -1,0 +1,241 @@
+package dk.ek.shift_happens.shift.mongo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * DTO for {@link ShiftDocument}. Mirrors the document's nested structure with
+ * nested records so the denormalised shift read model can be transferred
+ * without exposing the persistence document itself.
+ */
+public record ShiftDocumentDto(
+        Integer shiftId,
+        String shiftName,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
+        String shiftStatus,
+        Department department,
+        WorkLocation workLocation,
+        List<RequiredJobRole> requiredJobRoles,
+        List<ShiftAssignment> shiftAssignments
+) {
+    public static ShiftDocumentDto from(ShiftDocument d) {
+        return new ShiftDocumentDto(
+                d.getShiftId(),
+                d.getShiftName(),
+                d.getStartDateTime(),
+                d.getEndDateTime(),
+                d.getShiftStatus(),
+                Department.from(d.getDepartment()),
+                WorkLocation.from(d.getWorkLocation()),
+                mapList(d.getRequiredJobRoles(), RequiredJobRole::from),
+                mapList(d.getShiftAssignments(), ShiftAssignment::from)
+        );
+    }
+
+    public ShiftDocument toEntity() {
+        ShiftDocument d = new ShiftDocument();
+        d.setShiftId(shiftId);
+        d.setShiftName(shiftName);
+        d.setStartDateTime(startDateTime);
+        d.setEndDateTime(endDateTime);
+        d.setShiftStatus(shiftStatus);
+        d.setDepartment(department == null ? null : department.toEntity());
+        d.setWorkLocation(workLocation == null ? null : workLocation.toEntity());
+        d.setRequiredJobRoles(mapList(requiredJobRoles, RequiredJobRole::toEntity));
+        d.setShiftAssignments(mapList(shiftAssignments, ShiftAssignment::toEntity));
+        return d;
+    }
+
+    public record Department(Integer departmentId, String departmentName) {
+        static Department from(ShiftDocument.Department s) {
+            return s == null ? null : new Department(s.getDepartmentId(), s.getDepartmentName());
+        }
+
+        ShiftDocument.Department toEntity() {
+            ShiftDocument.Department s = new ShiftDocument.Department();
+            s.setDepartmentId(departmentId);
+            s.setDepartmentName(departmentName);
+            return s;
+        }
+    }
+
+    public record WorkLocation(Integer workLocationId, String locationName) {
+        static WorkLocation from(ShiftDocument.WorkLocation s) {
+            return s == null ? null : new WorkLocation(s.getWorkLocationId(), s.getLocationName());
+        }
+
+        ShiftDocument.WorkLocation toEntity() {
+            ShiftDocument.WorkLocation s = new ShiftDocument.WorkLocation();
+            s.setWorkLocationId(workLocationId);
+            s.setLocationName(locationName);
+            return s;
+        }
+    }
+
+    public record RequiredJobRole(Integer requiredEmployees, List<JobRole> jobRoles) {
+        static RequiredJobRole from(ShiftDocument.RequiredJobRole s) {
+            if (s == null) return null;
+            return new RequiredJobRole(s.getRequiredEmployees(), mapList(s.getJobRoles(), JobRole::from));
+        }
+
+        ShiftDocument.RequiredJobRole toEntity() {
+            ShiftDocument.RequiredJobRole s = new ShiftDocument.RequiredJobRole();
+            s.setRequiredEmployees(requiredEmployees);
+            s.setJobRoles(mapList(jobRoles, JobRole::toEntity));
+            return s;
+        }
+    }
+
+    public record JobRole(Integer jobRoleId, String roleName) {
+        static JobRole from(ShiftDocument.JobRole s) {
+            return s == null ? null : new JobRole(s.getJobRoleId(), s.getRoleName());
+        }
+
+        ShiftDocument.JobRole toEntity() {
+            ShiftDocument.JobRole s = new ShiftDocument.JobRole();
+            s.setJobRoleId(jobRoleId);
+            s.setRoleName(roleName);
+            return s;
+        }
+    }
+
+    public record ShiftAssignment(
+            AssignedEmployee assignedEmployee,
+            String assignmentStatus,
+            LocalDateTime assignmentDate,
+            LocalDateTime checkInDate,
+            LocalDateTime checkOutDatetime,
+            List<ShiftApproval> shiftApprovals,
+            List<SwapRequest> swapRequests
+    ) {
+        static ShiftAssignment from(ShiftDocument.ShiftAssignment s) {
+            if (s == null) return null;
+            return new ShiftAssignment(
+                    AssignedEmployee.from(s.getAssignedEmployee()),
+                    s.getAssignmentStatus(),
+                    s.getAssignmentDate(),
+                    s.getCheckInDate(),
+                    s.getCheckOutDatetime(),
+                    mapList(s.getShiftApprovals(), ShiftApproval::from),
+                    mapList(s.getSwapRequests(), SwapRequest::from)
+            );
+        }
+
+        ShiftDocument.ShiftAssignment toEntity() {
+            ShiftDocument.ShiftAssignment s = new ShiftDocument.ShiftAssignment();
+            s.setAssignedEmployee(assignedEmployee == null ? null : assignedEmployee.toEntity());
+            s.setAssignmentStatus(assignmentStatus);
+            s.setAssignmentDate(assignmentDate);
+            s.setCheckInDate(checkInDate);
+            s.setCheckOutDatetime(checkOutDatetime);
+            s.setShiftApprovals(mapList(shiftApprovals, ShiftApproval::toEntity));
+            s.setSwapRequests(mapList(swapRequests, SwapRequest::toEntity));
+            return s;
+        }
+    }
+
+    public record AssignedEmployee(Integer employeeId, String firstName, String lastName) {
+        static AssignedEmployee from(ShiftDocument.AssignedEmployee s) {
+            return s == null ? null
+                    : new AssignedEmployee(s.getEmployeeId(), s.getFirstName(), s.getLastName());
+        }
+
+        ShiftDocument.AssignedEmployee toEntity() {
+            ShiftDocument.AssignedEmployee s = new ShiftDocument.AssignedEmployee();
+            s.setEmployeeId(employeeId);
+            s.setFirstName(firstName);
+            s.setLastName(lastName);
+            return s;
+        }
+    }
+
+    public record ShiftApproval(
+            AssignedEmployee approverEmployee,
+            String decision,
+            String approvalComment,
+            LocalDateTime decisionDatetime
+    ) {
+        static ShiftApproval from(ShiftDocument.ShiftApproval s) {
+            if (s == null) return null;
+            return new ShiftApproval(
+                    AssignedEmployee.from(s.getApproverEmployee()),
+                    s.getDecision(),
+                    s.getApprovalComment(),
+                    s.getDecisionDatetime()
+            );
+        }
+
+        ShiftDocument.ShiftApproval toEntity() {
+            ShiftDocument.ShiftApproval s = new ShiftDocument.ShiftApproval();
+            s.setApproverEmployee(approverEmployee == null ? null : approverEmployee.toEntity());
+            s.setDecision(decision);
+            s.setApprovalComment(approvalComment);
+            s.setDecisionDatetime(decisionDatetime);
+            return s;
+        }
+    }
+
+    public record SwapRequest(
+            AssignedEmployee employeeFrom,
+            AssignedEmployee employeeTo,
+            String swapStatus,
+            LocalDateTime requestDatetime,
+            String reason,
+            List<SwapApproval> swapApprovals
+    ) {
+        static SwapRequest from(ShiftDocument.SwapRequest s) {
+            if (s == null) return null;
+            return new SwapRequest(
+                    AssignedEmployee.from(s.getEmployeeFrom()),
+                    AssignedEmployee.from(s.getEmployeeTo()),
+                    s.getSwapStatus(),
+                    s.getRequestDatetime(),
+                    s.getReason(),
+                    mapList(s.getSwapApprovals(), SwapApproval::from)
+            );
+        }
+
+        ShiftDocument.SwapRequest toEntity() {
+            ShiftDocument.SwapRequest s = new ShiftDocument.SwapRequest();
+            s.setEmployeeFrom(employeeFrom == null ? null : employeeFrom.toEntity());
+            s.setEmployeeTo(employeeTo == null ? null : employeeTo.toEntity());
+            s.setSwapStatus(swapStatus);
+            s.setRequestDatetime(requestDatetime);
+            s.setReason(reason);
+            s.setSwapApprovals(mapList(swapApprovals, SwapApproval::toEntity));
+            return s;
+        }
+    }
+
+    public record SwapApproval(
+            AssignedEmployee approverEmployee,
+            String decision,
+            String swapComment,
+            LocalDateTime decisionDatetime
+    ) {
+        static SwapApproval from(ShiftDocument.SwapApproval s) {
+            if (s == null) return null;
+            return new SwapApproval(
+                    AssignedEmployee.from(s.getApproverEmployee()),
+                    s.getDecision(),
+                    s.getSwapComment(),
+                    s.getDecisionDatetime()
+            );
+        }
+
+        ShiftDocument.SwapApproval toEntity() {
+            ShiftDocument.SwapApproval s = new ShiftDocument.SwapApproval();
+            s.setApproverEmployee(approverEmployee == null ? null : approverEmployee.toEntity());
+            s.setDecision(decision);
+            s.setSwapComment(swapComment);
+            s.setDecisionDatetime(decisionDatetime);
+            return s;
+        }
+    }
+
+    private static <S, T> List<T> mapList(List<S> src, Function<S, T> fn) {
+        return src == null ? null : src.stream().map(fn).toList();
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftMongoController {
 
-    private final ShiftMongoRepository shiftMongoRepository;
+    private final ShiftMongoService shiftMongoService;
 
     @GetMapping
     public List<ShiftDocumentDto> getAll() {
-        return shiftMongoRepository.findAll().stream().map(ShiftDocumentDto::from).toList();
+        return shiftMongoService.findAll().stream().map(ShiftDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public ShiftDocumentDto getById(@PathVariable Integer id) {
-        return shiftMongoRepository.findById(id)
+        return shiftMongoService.findById(id)
                 .map(ShiftDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public ShiftDocumentDto create(@RequestBody ShiftDocumentDto shift) {
-        return ShiftDocumentDto.from(shiftMongoRepository.save(shift.toEntity()));
+        return ShiftDocumentDto.from(shiftMongoService.create(shift.toEntity()));
     }
 
     @PutMapping("/{id}")
     public ShiftDocumentDto update(@PathVariable Integer id, @RequestBody ShiftDocumentDto shift) {
-        if (!shiftMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        ShiftDocument entity = shift.toEntity();
-        entity.setShiftId(id);
-        return ShiftDocumentDto.from(shiftMongoRepository.save(entity));
+        return shiftMongoService.update(id, shift.toEntity())
+                .map(ShiftDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        if (!shiftMongoRepository.existsById(id)) {
+        if (!shiftMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        shiftMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoController.java
@@ -15,28 +15,30 @@ public class ShiftMongoController {
     private final ShiftMongoRepository shiftMongoRepository;
 
     @GetMapping
-    public List<ShiftDocument> getAll() {
-        return shiftMongoRepository.findAll();
+    public List<ShiftDocumentDto> getAll() {
+        return shiftMongoRepository.findAll().stream().map(ShiftDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public ShiftDocument getById(@PathVariable Integer id) {
+    public ShiftDocumentDto getById(@PathVariable Integer id) {
         return shiftMongoRepository.findById(id)
+                .map(ShiftDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public ShiftDocument create(@RequestBody ShiftDocument shift) {
-        return shiftMongoRepository.save(shift);
+    public ShiftDocumentDto create(@RequestBody ShiftDocumentDto shift) {
+        return ShiftDocumentDto.from(shiftMongoRepository.save(shift.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public ShiftDocument update(@PathVariable Integer id, @RequestBody ShiftDocument shift) {
+    public ShiftDocumentDto update(@PathVariable Integer id, @RequestBody ShiftDocumentDto shift) {
         if (!shiftMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        shift.setShiftId(id);
-        return shiftMongoRepository.save(shift);
+        ShiftDocument entity = shift.toEntity();
+        entity.setShiftId(id);
+        return ShiftDocumentDto.from(shiftMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.shift.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftMongoService {
+
+    private final ShiftMongoRepository shiftMongoRepository;
+
+    public List<ShiftDocument> findAll() {
+        return shiftMongoRepository.findAll();
+    }
+
+    public Optional<ShiftDocument> findById(Integer id) {
+        return shiftMongoRepository.findById(id);
+    }
+
+    public ShiftDocument create(ShiftDocument document) {
+        return shiftMongoRepository.save(document);
+    }
+
+    public Optional<ShiftDocument> update(Integer id, ShiftDocument document) {
+        if (!shiftMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setShiftId(id);
+        return Optional.of(shiftMongoRepository.save(document));
+    }
+
+    public boolean delete(Integer id) {
+        if (!shiftMongoRepository.existsById(id)) {
+            return false;
+        }
+        shiftMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jController.java
@@ -15,13 +15,14 @@ public class ShiftNeo4jController {
     private final ShiftNeo4jRepository shiftNeo4jRepository;
 
     @GetMapping
-    public List<ShiftNode> getAll() {
-        return shiftNeo4jRepository.findAll();
+    public List<ShiftNodeDto> getAll() {
+        return shiftNeo4jRepository.findAll().stream().map(ShiftNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public ShiftNode getById(@PathVariable Long id) {
+    public ShiftNodeDto getById(@PathVariable Long id) {
         return shiftNeo4jRepository.findById(id)
+                .map(ShiftNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftNeo4jController {
 
-    private final ShiftNeo4jRepository shiftNeo4jRepository;
+    private final ShiftNeo4jService shiftNeo4jService;
 
     @GetMapping
     public List<ShiftNodeDto> getAll() {
-        return shiftNeo4jRepository.findAll().stream().map(ShiftNodeDto::from).toList();
+        return shiftNeo4jService.findAll().stream().map(ShiftNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public ShiftNodeDto getById(@PathVariable Long id) {
-        return shiftNeo4jRepository.findById(id)
+        return shiftNeo4jService.findById(id)
                 .map(ShiftNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.shift.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftNeo4jService {
+
+    private final ShiftNeo4jRepository shiftNeo4jRepository;
+
+    public List<ShiftNode> findAll() {
+        return shiftNeo4jRepository.findAll();
+    }
+
+    public Optional<ShiftNode> findById(Long id) {
+        return shiftNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNodeDto.java
@@ -1,0 +1,23 @@
+package dk.ek.shift_happens.shift.neo4j;
+
+import java.time.LocalDateTime;
+
+public record ShiftNodeDto(
+        Long id,
+        Integer shiftId,
+        String shiftName,
+        LocalDateTime startDatetime,
+        LocalDateTime endDatetime,
+        String shiftStatus
+) {
+    public static ShiftNodeDto from(ShiftNode n) {
+        return new ShiftNodeDto(
+                n.getId(),
+                n.getShiftId(),
+                n.getShiftName(),
+                n.getStartDatetime(),
+                n.getEndDatetime(),
+                n.getShiftStatus()
+        );
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalController.java
@@ -12,41 +12,37 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftApprovalController {
 
-    private final ShiftApprovalRepository shiftApprovalRepository;
+    private final ShiftApprovalService shiftApprovalService;
 
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public List<ShiftApprovalDto> getShiftApprovals() {
-        return this.shiftApprovalRepository.findAll().stream().map(ShiftApprovalDto::from).toList();
+        return this.shiftApprovalService.findAll().stream().map(ShiftApprovalDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public Optional<ShiftApprovalDto> getShiftApprovalById(@PathVariable Integer id) {
-        return this.shiftApprovalRepository.findById(id).map(ShiftApprovalDto::from);
+        return this.shiftApprovalService.findById(id).map(ShiftApprovalDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftApprovalDto createShiftApproval(@RequestBody ShiftApprovalDto shiftApproval) {
-        return ShiftApprovalDto.from(this.shiftApprovalRepository.save(shiftApproval.toEntity()));
+        return ShiftApprovalDto.from(this.shiftApprovalService.create(shiftApproval.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftApprovalDto updateShiftApproval(@PathVariable Integer id, @RequestBody ShiftApprovalDto shiftApprovalDetails) {
-        ShiftApproval shiftApproval = this.shiftApprovalRepository.findById(id).orElseThrow();
-        shiftApproval.setShiftAssignmentId(shiftApprovalDetails.shiftAssignmentId());
-        shiftApproval.setApproverEmployeeId(shiftApprovalDetails.approverEmployeeId());
-        shiftApproval.setDecision(shiftApprovalDetails.decision());
-        shiftApproval.setApprovalComment(shiftApprovalDetails.approvalComment());
-        shiftApproval.setDecisionDatetime(shiftApprovalDetails.decisionDatetime());
-        return ShiftApprovalDto.from(this.shiftApprovalRepository.save(shiftApproval));
+        return this.shiftApprovalService.update(id, shiftApprovalDetails.toEntity())
+                .map(ShiftApprovalDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftApproval(@PathVariable Integer id) {
-        this.shiftApprovalRepository.deleteById(id);
+        this.shiftApprovalService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalService.java
@@ -1,0 +1,41 @@
+package dk.ek.shift_happens.shiftapproval;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftApprovalService {
+
+    private final ShiftApprovalRepository shiftApprovalRepository;
+
+    public List<ShiftApproval> findAll() {
+        return shiftApprovalRepository.findAll();
+    }
+
+    public Optional<ShiftApproval> findById(Integer id) {
+        return shiftApprovalRepository.findById(id);
+    }
+
+    public ShiftApproval create(ShiftApproval shiftApproval) {
+        return shiftApprovalRepository.save(shiftApproval);
+    }
+
+    public Optional<ShiftApproval> update(Integer id, ShiftApproval updates) {
+        return shiftApprovalRepository.findById(id).map(existing -> {
+            existing.setShiftAssignmentId(updates.getShiftAssignmentId());
+            existing.setApproverEmployeeId(updates.getApproverEmployeeId());
+            existing.setDecision(updates.getDecision());
+            existing.setApprovalComment(updates.getApprovalComment());
+            existing.setDecisionDatetime(updates.getDecisionDatetime());
+            return shiftApprovalRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftApprovalRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentController.java
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftAssignmentController {
 
-    private final ShiftAssignmentRepository shiftAssignmentRepository;
+    private final ShiftAssignmentService shiftAssignmentService;
     private final AuthHelper authHelper;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<ShiftAssignmentDto> getShiftAssignments(Authentication auth) {
         List<ShiftAssignment> assignments = authHelper.isEmployee(auth)
-                ? shiftAssignmentRepository.findByEmployeeId(authHelper.currentEmployeeId(auth))
-                : this.shiftAssignmentRepository.findAll();
+                ? shiftAssignmentService.findByEmployeeId(authHelper.currentEmployeeId(auth))
+                : shiftAssignmentService.findAll();
         return assignments.stream().map(ShiftAssignmentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public ShiftAssignmentDto getShiftAssignmentById(@PathVariable Integer id, Authentication auth) {
-        ShiftAssignment assignment = shiftAssignmentRepository.findById(id)
+        ShiftAssignment assignment = shiftAssignmentService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         if (authHelper.isEmployee(auth)
                 && !assignment.getEmployeeId().equals(authHelper.currentEmployeeId(auth))) {
@@ -42,25 +42,20 @@ public class ShiftAssignmentController {
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftAssignmentDto createShiftAssignment(@RequestBody ShiftAssignmentDto shiftAssignment) {
-        return ShiftAssignmentDto.from(this.shiftAssignmentRepository.save(shiftAssignment.toEntity()));
+        return ShiftAssignmentDto.from(shiftAssignmentService.create(shiftAssignment.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftAssignmentDto updateShiftAssignment(@PathVariable Integer id, @RequestBody ShiftAssignmentDto shiftAssignmentDetails) {
-        ShiftAssignment shiftAssignment = this.shiftAssignmentRepository.findById(id).orElseThrow();
-        shiftAssignment.setShiftId(shiftAssignmentDetails.shiftId());
-        shiftAssignment.setEmployeeId(shiftAssignmentDetails.employeeId());
-        shiftAssignment.setAssignmentStatus(shiftAssignmentDetails.assignmentStatus());
-        shiftAssignment.setAssignedDatetime(shiftAssignmentDetails.assignedDatetime());
-        shiftAssignment.setCheckInDatetime(shiftAssignmentDetails.checkInDatetime());
-        shiftAssignment.setCheckOutDatetime(shiftAssignmentDetails.checkOutDatetime());
-        return ShiftAssignmentDto.from(this.shiftAssignmentRepository.save(shiftAssignment));
+        return shiftAssignmentService.update(id, shiftAssignmentDetails.toEntity())
+                .map(ShiftAssignmentDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftAssignment(@PathVariable Integer id) {
-        this.shiftAssignmentRepository.deleteById(id);
+        shiftAssignmentService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentService.java
@@ -1,0 +1,46 @@
+package dk.ek.shift_happens.shiftassignment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftAssignmentService {
+
+    private final ShiftAssignmentRepository shiftAssignmentRepository;
+
+    public List<ShiftAssignment> findAll() {
+        return shiftAssignmentRepository.findAll();
+    }
+
+    public List<ShiftAssignment> findByEmployeeId(Integer employeeId) {
+        return shiftAssignmentRepository.findByEmployeeId(employeeId);
+    }
+
+    public Optional<ShiftAssignment> findById(Integer id) {
+        return shiftAssignmentRepository.findById(id);
+    }
+
+    public ShiftAssignment create(ShiftAssignment shiftAssignment) {
+        return shiftAssignmentRepository.save(shiftAssignment);
+    }
+
+    public Optional<ShiftAssignment> update(Integer id, ShiftAssignment updates) {
+        return shiftAssignmentRepository.findById(id).map(existing -> {
+            existing.setShiftId(updates.getShiftId());
+            existing.setEmployeeId(updates.getEmployeeId());
+            existing.setAssignmentStatus(updates.getAssignmentStatus());
+            existing.setAssignedDatetime(updates.getAssignedDatetime());
+            existing.setCheckInDatetime(updates.getCheckInDatetime());
+            existing.setCheckOutDatetime(updates.getCheckOutDatetime());
+            return shiftAssignmentRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftAssignmentRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleController.java
@@ -12,40 +12,38 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftRequiredJobRoleController {
 
-    private final ShiftRequiredJobRoleRepository shiftRequiredJobRoleRepository;
+    private final ShiftRequiredJobRoleService shiftRequiredJobRoleService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<ShiftRequiredJobRoleDto> getShiftRequiredJobRoles() {
-        return this.shiftRequiredJobRoleRepository.findAll().stream()
+        return this.shiftRequiredJobRoleService.findAll().stream()
                 .map(ShiftRequiredJobRoleDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public Optional<ShiftRequiredJobRoleDto> getShiftRequiredJobRoleById(@PathVariable Integer id) {
-        return this.shiftRequiredJobRoleRepository.findById(id).map(ShiftRequiredJobRoleDto::from);
+        return this.shiftRequiredJobRoleService.findById(id).map(ShiftRequiredJobRoleDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftRequiredJobRoleDto createShiftRequiredJobRole(@RequestBody ShiftRequiredJobRoleDto shiftRequiredJobRole) {
-        return ShiftRequiredJobRoleDto.from(this.shiftRequiredJobRoleRepository.save(shiftRequiredJobRole.toEntity()));
+        return ShiftRequiredJobRoleDto.from(this.shiftRequiredJobRoleService.create(shiftRequiredJobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftRequiredJobRoleDto updateShiftRequiredJobRole(@PathVariable Integer id, @RequestBody ShiftRequiredJobRoleDto shiftRequiredJobRoleDetails) {
-        ShiftRequiredJobRole shiftRequiredJobRole = this.shiftRequiredJobRoleRepository.findById(id).orElseThrow();
-        shiftRequiredJobRole.setShiftId(shiftRequiredJobRoleDetails.shiftId());
-        shiftRequiredJobRole.setJobRoleId(shiftRequiredJobRoleDetails.jobRoleId());
-        shiftRequiredJobRole.setRequiredEmployeeCount(shiftRequiredJobRoleDetails.requiredEmployeeCount());
-        return ShiftRequiredJobRoleDto.from(this.shiftRequiredJobRoleRepository.save(shiftRequiredJobRole));
+        return this.shiftRequiredJobRoleService.update(id, shiftRequiredJobRoleDetails.toEntity())
+                .map(ShiftRequiredJobRoleDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftRequiredJobRole(@PathVariable Integer id) {
-        this.shiftRequiredJobRoleRepository.deleteById(id);
+        this.shiftRequiredJobRoleService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleService.java
@@ -1,0 +1,39 @@
+package dk.ek.shift_happens.shiftrequiredjobrole;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftRequiredJobRoleService {
+
+    private final ShiftRequiredJobRoleRepository shiftRequiredJobRoleRepository;
+
+    public List<ShiftRequiredJobRole> findAll() {
+        return shiftRequiredJobRoleRepository.findAll();
+    }
+
+    public Optional<ShiftRequiredJobRole> findById(Integer id) {
+        return shiftRequiredJobRoleRepository.findById(id);
+    }
+
+    public ShiftRequiredJobRole create(ShiftRequiredJobRole shiftRequiredJobRole) {
+        return shiftRequiredJobRoleRepository.save(shiftRequiredJobRole);
+    }
+
+    public Optional<ShiftRequiredJobRole> update(Integer id, ShiftRequiredJobRole updates) {
+        return shiftRequiredJobRoleRepository.findById(id).map(existing -> {
+            existing.setShiftId(updates.getShiftId());
+            existing.setJobRoleId(updates.getJobRoleId());
+            existing.setRequiredEmployeeCount(updates.getRequiredEmployeeCount());
+            return shiftRequiredJobRoleRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftRequiredJobRoleRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftSwapController {
 
-    private final ShiftSwapRepository shiftSwapRepository;
+    private final ShiftSwapService shiftSwapService;
     private final AuthHelper authHelper;
 
     @GetMapping
@@ -24,9 +24,9 @@ public class ShiftSwapController {
         List<ShiftSwap> swaps;
         if (authHelper.isEmployee(auth)) {
             Integer self = authHelper.currentEmployeeId(auth);
-            swaps = shiftSwapRepository.findByEmployeeFromIdOrEmployeeToId(self, self);
+            swaps = shiftSwapService.findByEmployee(self);
         } else {
-            swaps = this.shiftSwapRepository.findAll();
+            swaps = shiftSwapService.findAll();
         }
         return swaps.stream().map(ShiftSwapDto::from).toList();
     }
@@ -34,7 +34,7 @@ public class ShiftSwapController {
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public ShiftSwapDto getShiftSwapById(@PathVariable Integer id, Authentication auth) {
-        ShiftSwap swap = shiftSwapRepository.findById(id)
+        ShiftSwap swap = shiftSwapService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         if (authHelper.isEmployee(auth)) {
             Integer self = authHelper.currentEmployeeId(auth);
@@ -48,25 +48,20 @@ public class ShiftSwapController {
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapDto createShiftSwap(@RequestBody ShiftSwapDto shiftSwap) {
-        return ShiftSwapDto.from(this.shiftSwapRepository.save(shiftSwap.toEntity()));
+        return ShiftSwapDto.from(shiftSwapService.create(shiftSwap.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapDto updateShiftSwap(@PathVariable Integer id, @RequestBody ShiftSwapDto shiftSwapDetails) {
-        ShiftSwap shiftSwap = this.shiftSwapRepository.findById(id).orElseThrow();
-        shiftSwap.setOriginalShiftAssignmentId(shiftSwapDetails.originalShiftAssignmentId());
-        shiftSwap.setEmployeeFromId(shiftSwapDetails.employeeFromId());
-        shiftSwap.setEmployeeToId(shiftSwapDetails.employeeToId());
-        shiftSwap.setSwapStatus(shiftSwapDetails.swapStatus());
-        shiftSwap.setRequestDatetime(shiftSwapDetails.requestDatetime());
-        shiftSwap.setReason(shiftSwapDetails.reason());
-        return ShiftSwapDto.from(this.shiftSwapRepository.save(shiftSwap));
+        return shiftSwapService.update(id, shiftSwapDetails.toEntity())
+                .map(ShiftSwapDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftSwap(@PathVariable Integer id) {
-        this.shiftSwapRepository.deleteById(id);
+        shiftSwapService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapService.java
@@ -1,0 +1,46 @@
+package dk.ek.shift_happens.shiftswap;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftSwapService {
+
+    private final ShiftSwapRepository shiftSwapRepository;
+
+    public List<ShiftSwap> findAll() {
+        return shiftSwapRepository.findAll();
+    }
+
+    public List<ShiftSwap> findByEmployee(Integer employeeId) {
+        return shiftSwapRepository.findByEmployeeFromIdOrEmployeeToId(employeeId, employeeId);
+    }
+
+    public Optional<ShiftSwap> findById(Integer id) {
+        return shiftSwapRepository.findById(id);
+    }
+
+    public ShiftSwap create(ShiftSwap shiftSwap) {
+        return shiftSwapRepository.save(shiftSwap);
+    }
+
+    public Optional<ShiftSwap> update(Integer id, ShiftSwap updates) {
+        return shiftSwapRepository.findById(id).map(existing -> {
+            existing.setOriginalShiftAssignmentId(updates.getOriginalShiftAssignmentId());
+            existing.setEmployeeFromId(updates.getEmployeeFromId());
+            existing.setEmployeeToId(updates.getEmployeeToId());
+            existing.setSwapStatus(updates.getSwapStatus());
+            existing.setRequestDatetime(updates.getRequestDatetime());
+            existing.setReason(updates.getReason());
+            return shiftSwapRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftSwapRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jController.java
@@ -20,13 +20,14 @@ public class ShiftSwapNeo4jController {
     private final ShiftSwapNeo4jService shiftSwapNeo4jService;
 
     @GetMapping
-    public List<ShiftSwapNode> getAll() {
-        return shiftSwapNeo4jRepository.findAll();
+    public List<ShiftSwapNodeDto> getAll() {
+        return shiftSwapNeo4jRepository.findAll().stream().map(ShiftSwapNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ShiftSwapNode> getById(@PathVariable Long id) {
+    public ResponseEntity<ShiftSwapNodeDto> getById(@PathVariable Long id) {
         return shiftSwapNeo4jRepository.findById(id)
+                .map(ShiftSwapNodeDto::from)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jController.java
@@ -1,12 +1,9 @@
 package dk.ek.shift_happens.shiftswap.neo4j;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -15,18 +12,16 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ShiftSwapNeo4jController {
 
-    private final ShiftSwapNeo4jRepository shiftSwapNeo4jRepository;
-    private final Neo4jClient neo4jClient;
     private final ShiftSwapNeo4jService shiftSwapNeo4jService;
 
     @GetMapping
     public List<ShiftSwapNodeDto> getAll() {
-        return shiftSwapNeo4jRepository.findAll().stream().map(ShiftSwapNodeDto::from).toList();
+        return shiftSwapNeo4jService.findAll().stream().map(ShiftSwapNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ShiftSwapNodeDto> getById(@PathVariable Long id) {
-        return shiftSwapNeo4jRepository.findById(id)
+        return shiftSwapNeo4jService.findById(id)
                 .map(ShiftSwapNodeDto::from)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -34,83 +29,13 @@ public class ShiftSwapNeo4jController {
 
     @GetMapping("/candidates/{shiftId}")
     public ResponseEntity<List<Map<String, Object>>> getSwapCandidates(@PathVariable Integer shiftId) {
-        String cypher = """
-                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
-                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
-                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
-                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
-                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
-                  }
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
-                      WHERE other.startDatetime < target.endDatetime
-                        AND other.endDatetime > target.startDatetime
-                  }
-                OPTIONAL MATCH (candidate)-[:WORKS_AT_LOCATION]->(location:WorkLocation)
-                  WITH target, targetDepartment, candidate, location,
-                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
-                RETURN target.shiftId AS shiftId,
-                       target.shiftName AS shiftName,
-                       candidate.employeeId AS employeeId,
-                       candidate.employeeNumber AS employeeNumber,
-                       candidate.firstName AS firstName,
-                       candidate.lastName AS lastName,
-                       candidate.email AS email,
-                      targetDepartment.departmentName AS department,
-                       location.locationName AS location,
-                       matchingRoles
-                ORDER BY candidate.firstName, candidate.lastName
-                """;
-
-        return ResponseEntity.ok(runCandidateQuery(cypher, shiftId));
+        return ResponseEntity.ok(shiftSwapNeo4jService.findSwapCandidates(shiftId));
     }
 
     //kræver lige nu auth adgang, jeg tro fordi den bruger nået employe data som kun må tilgås som manager.
     @GetMapping("/candidates/location/{shiftId}")
     public ResponseEntity<List<Map<String, Object>>> getSwapCandidatesSameDepartmentAndLocation(@PathVariable Integer shiftId) {
-        String cypher = """
-                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
-                MATCH (target)-[:SHIFT_AT_LOCATION]->(targetLocation:WorkLocation)
-                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
-                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
-                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
-                MATCH (candidate)-[:WORKS_AT_LOCATION]->(targetLocation)
-                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
-                  }
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
-                      WHERE other.startDatetime < target.endDatetime
-                        AND other.endDatetime > target.startDatetime
-                  }
-                WITH target, targetDepartment, targetLocation, candidate,
-                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
-                RETURN target.shiftId AS shiftId,
-                       target.shiftName AS shiftName,
-                       candidate.employeeId AS employeeId,
-                       candidate.employeeNumber AS employeeNumber,
-                       candidate.firstName AS firstName,
-                       candidate.lastName AS lastName,
-                       candidate.email AS email,
-                       targetDepartment.departmentName AS department,
-                       targetLocation.locationName AS location,
-                       matchingRoles
-                ORDER BY candidate.firstName, candidate.lastName
-                """;
-
-        return ResponseEntity.ok(runCandidateQuery(cypher, shiftId));
-    }
-
-    private List<Map<String, Object>> runCandidateQuery(String cypher, Integer shiftId) {
-        Collection<Map<String, Object>> rows = neo4jClient.query(cypher)
-                .bind(shiftId).to("shiftId")
-                .fetch()
-                .all();
-
-        return new ArrayList<>(rows);
+        return ResponseEntity.ok(shiftSwapNeo4jService.findSwapCandidatesSameDepartmentAndLocation(shiftId));
     }
 
     /**

--- a/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jService.java
@@ -5,6 +5,9 @@ import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -12,7 +15,100 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftSwapNeo4jService {
 
+    private final ShiftSwapNeo4jRepository shiftSwapNeo4jRepository;
     private final Neo4jClient neo4jClient;
+
+    public List<ShiftSwapNode> findAll() {
+        return shiftSwapNeo4jRepository.findAll();
+    }
+
+    public Optional<ShiftSwapNode> findById(Long id) {
+        return shiftSwapNeo4jRepository.findById(id);
+    }
+
+    /**
+     * Returns swap candidates for a shift: active employees who hold a required
+     * role, work in the shift's department, and have no conflicting assignment.
+     */
+    public List<Map<String, Object>> findSwapCandidates(Integer shiftId) {
+        String cypher = """
+                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
+                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
+                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
+                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
+                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
+                  }
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
+                      WHERE other.startDatetime < target.endDatetime
+                        AND other.endDatetime > target.startDatetime
+                  }
+                OPTIONAL MATCH (candidate)-[:WORKS_AT_LOCATION]->(location:WorkLocation)
+                  WITH target, targetDepartment, candidate, location,
+                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
+                RETURN target.shiftId AS shiftId,
+                       target.shiftName AS shiftName,
+                       candidate.employeeId AS employeeId,
+                       candidate.employeeNumber AS employeeNumber,
+                       candidate.firstName AS firstName,
+                       candidate.lastName AS lastName,
+                       candidate.email AS email,
+                      targetDepartment.departmentName AS department,
+                       location.locationName AS location,
+                       matchingRoles
+                ORDER BY candidate.firstName, candidate.lastName
+                """;
+        return runCandidateQuery(cypher, shiftId);
+    }
+
+    /**
+     * As {@link #findSwapCandidates}, but additionally constrained to candidates
+     * who work at the shift's location.
+     */
+    public List<Map<String, Object>> findSwapCandidatesSameDepartmentAndLocation(Integer shiftId) {
+        String cypher = """
+                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
+                MATCH (target)-[:SHIFT_AT_LOCATION]->(targetLocation:WorkLocation)
+                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
+                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
+                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
+                MATCH (candidate)-[:WORKS_AT_LOCATION]->(targetLocation)
+                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
+                  }
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
+                      WHERE other.startDatetime < target.endDatetime
+                        AND other.endDatetime > target.startDatetime
+                  }
+                WITH target, targetDepartment, targetLocation, candidate,
+                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
+                RETURN target.shiftId AS shiftId,
+                       target.shiftName AS shiftName,
+                       candidate.employeeId AS employeeId,
+                       candidate.employeeNumber AS employeeNumber,
+                       candidate.firstName AS firstName,
+                       candidate.lastName AS lastName,
+                       candidate.email AS email,
+                       targetDepartment.departmentName AS department,
+                       targetLocation.locationName AS location,
+                       matchingRoles
+                ORDER BY candidate.firstName, candidate.lastName
+                """;
+        return runCandidateQuery(cypher, shiftId);
+    }
+
+    private List<Map<String, Object>> runCandidateQuery(String cypher, Integer shiftId) {
+        Collection<Map<String, Object>> rows = neo4jClient.query(cypher)
+                .bind(shiftId).to("shiftId")
+                .fetch()
+                .all();
+
+        return new ArrayList<>(rows);
+    }
 
     /**
      * Executes a shift swap inside a single Neo4j transaction:

--- a/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNodeDto.java
@@ -1,0 +1,27 @@
+package dk.ek.shift_happens.shiftswap.neo4j;
+
+import java.time.LocalDateTime;
+
+public record ShiftSwapNodeDto(
+        Long id,
+        Integer shiftSwapId,
+        Integer originalShiftAssignmentId,
+        Integer employeeFromId,
+        Integer employeeToId,
+        String swapStatus,
+        LocalDateTime requestDatetime,
+        String reason
+) {
+    public static ShiftSwapNodeDto from(ShiftSwapNode n) {
+        return new ShiftSwapNodeDto(
+                n.getId(),
+                n.getShiftSwapId(),
+                n.getOriginalShiftAssignmentId(),
+                n.getEmployeeFromId(),
+                n.getEmployeeToId(),
+                n.getSwapStatus(),
+                n.getRequestDatetime(),
+                n.getReason()
+        );
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalController.java
@@ -12,41 +12,37 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftSwapApprovalController {
 
-    private final ShiftSwapApprovalRepository shiftSwapApprovalRepository;
+    private final ShiftSwapApprovalService shiftSwapApprovalService;
 
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public List<ShiftSwapApprovalDto> getShiftSwapApprovals() {
-        return this.shiftSwapApprovalRepository.findAll().stream().map(ShiftSwapApprovalDto::from).toList();
+        return this.shiftSwapApprovalService.findAll().stream().map(ShiftSwapApprovalDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public Optional<ShiftSwapApprovalDto> getShiftSwapApprovalById(@PathVariable Integer id) {
-        return this.shiftSwapApprovalRepository.findById(id).map(ShiftSwapApprovalDto::from);
+        return this.shiftSwapApprovalService.findById(id).map(ShiftSwapApprovalDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapApprovalDto createShiftSwapApproval(@RequestBody ShiftSwapApprovalDto shiftSwapApproval) {
-        return ShiftSwapApprovalDto.from(this.shiftSwapApprovalRepository.save(shiftSwapApproval.toEntity()));
+        return ShiftSwapApprovalDto.from(this.shiftSwapApprovalService.create(shiftSwapApproval.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapApprovalDto updateShiftSwapApproval(@PathVariable Integer id, @RequestBody ShiftSwapApprovalDto shiftSwapApprovalDetails) {
-        ShiftSwapApproval shiftSwapApproval = this.shiftSwapApprovalRepository.findById(id).orElseThrow();
-        shiftSwapApproval.setShiftSwapId(shiftSwapApprovalDetails.shiftSwapId());
-        shiftSwapApproval.setApproverEmployeeId(shiftSwapApprovalDetails.approverEmployeeId());
-        shiftSwapApproval.setDecision(shiftSwapApprovalDetails.decision());
-        shiftSwapApproval.setShiftSwapComment(shiftSwapApprovalDetails.shiftSwapComment());
-        shiftSwapApproval.setDecisionDatetime(shiftSwapApprovalDetails.decisionDatetime());
-        return ShiftSwapApprovalDto.from(this.shiftSwapApprovalRepository.save(shiftSwapApproval));
+        return this.shiftSwapApprovalService.update(id, shiftSwapApprovalDetails.toEntity())
+                .map(ShiftSwapApprovalDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftSwapApproval(@PathVariable Integer id) {
-        this.shiftSwapApprovalRepository.deleteById(id);
+        this.shiftSwapApprovalService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalService.java
@@ -1,0 +1,41 @@
+package dk.ek.shift_happens.shiftswapapproval;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftSwapApprovalService {
+
+    private final ShiftSwapApprovalRepository shiftSwapApprovalRepository;
+
+    public List<ShiftSwapApproval> findAll() {
+        return shiftSwapApprovalRepository.findAll();
+    }
+
+    public Optional<ShiftSwapApproval> findById(Integer id) {
+        return shiftSwapApprovalRepository.findById(id);
+    }
+
+    public ShiftSwapApproval create(ShiftSwapApproval shiftSwapApproval) {
+        return shiftSwapApprovalRepository.save(shiftSwapApproval);
+    }
+
+    public Optional<ShiftSwapApproval> update(Integer id, ShiftSwapApproval updates) {
+        return shiftSwapApprovalRepository.findById(id).map(existing -> {
+            existing.setShiftSwapId(updates.getShiftSwapId());
+            existing.setApproverEmployeeId(updates.getApproverEmployeeId());
+            existing.setDecision(updates.getDecision());
+            existing.setShiftSwapComment(updates.getShiftSwapComment());
+            existing.setDecisionDatetime(updates.getDecisionDatetime());
+            return shiftSwapApprovalRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftSwapApprovalRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationController.java
@@ -13,18 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkLocationController {
 
-    private final WorkLocationRepository workLocationRepository;
+    private final WorkLocationService workLocationService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<WorkLocationDto> getAll() {
-        return workLocationRepository.findAll().stream().map(WorkLocationDto::from).toList();
+        return workLocationService.findAll().stream().map(WorkLocationDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public WorkLocationDto getById(@PathVariable Integer id) {
-        return workLocationRepository.findById(id)
+        return workLocationService.findById(id)
                 .map(WorkLocationDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -33,28 +33,21 @@ public class WorkLocationController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public WorkLocationDto create(@RequestBody WorkLocationDto workLocation) {
-        return WorkLocationDto.from(workLocationRepository.save(workLocation.toEntity()));
+        return WorkLocationDto.from(workLocationService.create(workLocation.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public WorkLocationDto update(@PathVariable Integer id, @RequestBody WorkLocationDto details) {
-        WorkLocation existing = workLocationRepository.findById(id)
+        return workLocationService.update(id, details.toEntity())
+                .map(WorkLocationDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setLocationName(details.locationName());
-        existing.setAddressLine1(details.addressLine1());
-        existing.setAddressLine2(details.addressLine2());
-        existing.setCity(details.city());
-        existing.setCountry(details.country());
-        existing.setTimezone(details.timezone());
-        existing.setIsActive(details.isActive());
-        return WorkLocationDto.from(workLocationRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        workLocationRepository.deleteById(id);
+        workLocationService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationService.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationService.java
@@ -1,0 +1,43 @@
+package dk.ek.shift_happens.worklocation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkLocationService {
+
+    private final WorkLocationRepository workLocationRepository;
+
+    public List<WorkLocation> findAll() {
+        return workLocationRepository.findAll();
+    }
+
+    public Optional<WorkLocation> findById(Integer id) {
+        return workLocationRepository.findById(id);
+    }
+
+    public WorkLocation create(WorkLocation workLocation) {
+        return workLocationRepository.save(workLocation);
+    }
+
+    public Optional<WorkLocation> update(Integer id, WorkLocation updates) {
+        return workLocationRepository.findById(id).map(existing -> {
+            existing.setLocationName(updates.getLocationName());
+            existing.setAddressLine1(updates.getAddressLine1());
+            existing.setAddressLine2(updates.getAddressLine2());
+            existing.setCity(updates.getCity());
+            existing.setCountry(updates.getCountry());
+            existing.setTimezone(updates.getTimezone());
+            existing.setIsActive(updates.getIsActive());
+            return workLocationRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        workLocationRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationDocumentDto.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationDocumentDto.java
@@ -1,0 +1,41 @@
+package dk.ek.shift_happens.worklocation.mongo;
+
+public record WorkLocationDocumentDto(
+        String id,
+        Integer workLocationId,
+        String locationName,
+        String addressLine1,
+        String addressLine2,
+        String city,
+        String country,
+        String timezone,
+        Boolean isActive
+) {
+    public static WorkLocationDocumentDto from(WorkLocationDocument w) {
+        return new WorkLocationDocumentDto(
+                w.getId(),
+                w.getWorkLocationId(),
+                w.getLocationName(),
+                w.getAddressLine1(),
+                w.getAddressLine2(),
+                w.getCity(),
+                w.getCountry(),
+                w.getTimezone(),
+                w.getIsActive()
+        );
+    }
+
+    public WorkLocationDocument toEntity() {
+        WorkLocationDocument w = new WorkLocationDocument();
+        w.setId(id);
+        w.setWorkLocationId(workLocationId);
+        w.setLocationName(locationName);
+        w.setAddressLine1(addressLine1);
+        w.setAddressLine2(addressLine2);
+        w.setCity(city);
+        w.setCountry(country);
+        w.setTimezone(timezone);
+        w.setIsActive(isActive);
+        return w;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkLocationMongoController {
 
-    private final WorkLocationMongoRepository workLocationMongoRepository;
+    private final WorkLocationMongoService workLocationMongoService;
 
     @GetMapping
     public List<WorkLocationDocumentDto> getAll() {
-        return workLocationMongoRepository.findAll().stream().map(WorkLocationDocumentDto::from).toList();
+        return workLocationMongoService.findAll().stream().map(WorkLocationDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public WorkLocationDocumentDto getById(@PathVariable String id) {
-        return workLocationMongoRepository.findById(id)
+        return workLocationMongoService.findById(id)
                 .map(WorkLocationDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public WorkLocationDocumentDto create(@RequestBody WorkLocationDocumentDto workLocation) {
-        return WorkLocationDocumentDto.from(workLocationMongoRepository.save(workLocation.toEntity()));
+        return WorkLocationDocumentDto.from(workLocationMongoService.create(workLocation.toEntity()));
     }
 
     @PutMapping("/{id}")
     public WorkLocationDocumentDto update(@PathVariable String id, @RequestBody WorkLocationDocumentDto workLocation) {
-        if (!workLocationMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        WorkLocationDocument entity = workLocation.toEntity();
-        entity.setId(id);
-        return WorkLocationDocumentDto.from(workLocationMongoRepository.save(entity));
+        return workLocationMongoService.update(id, workLocation.toEntity())
+                .map(WorkLocationDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!workLocationMongoRepository.existsById(id)) {
+        if (!workLocationMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        workLocationMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoController.java
@@ -15,28 +15,30 @@ public class WorkLocationMongoController {
     private final WorkLocationMongoRepository workLocationMongoRepository;
 
     @GetMapping
-    public List<WorkLocationDocument> getAll() {
-        return workLocationMongoRepository.findAll();
+    public List<WorkLocationDocumentDto> getAll() {
+        return workLocationMongoRepository.findAll().stream().map(WorkLocationDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public WorkLocationDocument getById(@PathVariable String id) {
+    public WorkLocationDocumentDto getById(@PathVariable String id) {
         return workLocationMongoRepository.findById(id)
+                .map(WorkLocationDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
-    public WorkLocationDocument create(@RequestBody WorkLocationDocument workLocation) {
-        return workLocationMongoRepository.save(workLocation);
+    public WorkLocationDocumentDto create(@RequestBody WorkLocationDocumentDto workLocation) {
+        return WorkLocationDocumentDto.from(workLocationMongoRepository.save(workLocation.toEntity()));
     }
 
     @PutMapping("/{id}")
-    public WorkLocationDocument update(@PathVariable String id, @RequestBody WorkLocationDocument workLocation) {
+    public WorkLocationDocumentDto update(@PathVariable String id, @RequestBody WorkLocationDocumentDto workLocation) {
         if (!workLocationMongoRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        workLocation.setId(id);
-        return workLocationMongoRepository.save(workLocation);
+        WorkLocationDocument entity = workLocation.toEntity();
+        entity.setId(id);
+        return WorkLocationDocumentDto.from(workLocationMongoRepository.save(entity));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.worklocation.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkLocationMongoService {
+
+    private final WorkLocationMongoRepository workLocationMongoRepository;
+
+    public List<WorkLocationDocument> findAll() {
+        return workLocationMongoRepository.findAll();
+    }
+
+    public Optional<WorkLocationDocument> findById(String id) {
+        return workLocationMongoRepository.findById(id);
+    }
+
+    public WorkLocationDocument create(WorkLocationDocument document) {
+        return workLocationMongoRepository.save(document);
+    }
+
+    public Optional<WorkLocationDocument> update(String id, WorkLocationDocument document) {
+        if (!workLocationMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(workLocationMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!workLocationMongoRepository.existsById(id)) {
+            return false;
+        }
+        workLocationMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jController.java
@@ -15,13 +15,14 @@ public class WorkLocationNeo4jController {
     private final WorkLocationNeo4jRepository workLocationNeo4jRepository;
 
     @GetMapping
-    public List<WorkLocationNode> getAll() {
-        return workLocationNeo4jRepository.findAll();
+    public List<WorkLocationNodeDto> getAll() {
+        return workLocationNeo4jRepository.findAll().stream().map(WorkLocationNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
-    public WorkLocationNode getById(@PathVariable Long id) {
+    public WorkLocationNodeDto getById(@PathVariable Long id) {
         return workLocationNeo4jRepository.findById(id)
+                .map(WorkLocationNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkLocationNeo4jController {
 
-    private final WorkLocationNeo4jRepository workLocationNeo4jRepository;
+    private final WorkLocationNeo4jService workLocationNeo4jService;
 
     @GetMapping
     public List<WorkLocationNodeDto> getAll() {
-        return workLocationNeo4jRepository.findAll().stream().map(WorkLocationNodeDto::from).toList();
+        return workLocationNeo4jService.findAll().stream().map(WorkLocationNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public WorkLocationNodeDto getById(@PathVariable Long id) {
-        return workLocationNeo4jRepository.findById(id)
+        return workLocationNeo4jService.findById(id)
                 .map(WorkLocationNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.worklocation.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkLocationNeo4jService {
+
+    private final WorkLocationNeo4jRepository workLocationNeo4jRepository;
+
+    public List<WorkLocationNode> findAll() {
+        return workLocationNeo4jRepository.findAll();
+    }
+
+    public Optional<WorkLocationNode> findById(Long id) {
+        return workLocationNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNodeDto.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNodeDto.java
@@ -1,0 +1,23 @@
+package dk.ek.shift_happens.worklocation.neo4j;
+
+public record WorkLocationNodeDto(
+        Long id,
+        Integer workLocationId,
+        String locationName,
+        String city,
+        String country,
+        String timezone,
+        Boolean isActive
+) {
+    public static WorkLocationNodeDto from(WorkLocationNode n) {
+        return new WorkLocationNodeDto(
+                n.getId(),
+                n.getWorkLocationId(),
+                n.getLocationName(),
+                n.getCity(),
+                n.getCountry(),
+                n.getTimezone(),
+                n.getIsActive()
+        );
+    }
+}


### PR DESCRIPTION
## What

Migrates the **8 MongoDB controllers** from accepting and returning raw
`@Document` classes to using **DTO records**, per the assignment requirement:
*"use DTO objects in the controllers. Do not expose the models to the
outside."*

- **8 new DTO files**, **8 controllers rewritten**.
- DTOs named `XDocumentDto` to avoid clashing with the JPA-side `XDto`.
- Updates `docs/dto-rationale.md` with the Mongo section and follow-ups.

### Flat reference docs (5)
Department, JobRole, LeaveType, WorkLocation, AuditLog — flat `XDocumentDto`
records, same pattern as the JPA entities.

### Denormalised aggregate docs (3)
Employee, Shift, Leave — deep trees of embedded sub-documents, each mirrored
by a nested DTO `record` (~19 nested records total).

## Why

Same rationale as the SQL DTO PR — a DTO is an API-boundary concern, not a
SQL-specific one.

**Security — this PR fixes a real leak:** `EmployeeDocument.loginPassword` was
exposed with **no protection at all** (unlike the JPA `Employee`). Every
`/mongo/employees` response was returning password hashes. `EmployeeDocumentDto`
makes `loginPassword` write-only and drops the embedded `salaryAmount`.

## Design note

The 3 denormalised aggregates are mirrored 1:1 with nested records. For
`EmployeeDocument` this has real security value; for `ShiftDocument` /
`LeaveDocument` it is mainly **consistency** value (no sensitive data) — kept
because the requirement is unconditional and a uniform rule is easier to
defend than a carve-out.

## Verification

- `mvn compile` — clean.
- `mvn test` — **6/6 pass** (`BUILD SUCCESS`).
- Frontend does not consume `/mongo` endpoints.

## Known follow-ups (out of scope)

- The 13 **Neo4j controllers** still return `@Node` entities — a later branch.
- **Mongo controllers have no service layer** — they call repositories
  directly, whereas the assignment asks for `controllers -> services ->
  repositories`.
- **Mongo controllers have no `@PreAuthorize`** — unauthenticated, unlike the
  JPA controllers.

---

Note: stacked on #109 (the SQL DTO PR). Base will retarget to `main` once
#109 merges.