### PR TITLE
Add service layer to all controllers

### DIFF
--- a/docs/db-mandatory-progress.md
+++ b/docs/db-mandatory-progress.md
@@ -1,0 +1,81 @@
+# DB Mandatory — Progress & Handoff
+
+State of the DTO + layered-architecture work on the `shift_happens` project.
+Read this first when resuming. Companion docs: `dto-rationale.md`,
+`service-layer.md`.
+
+## Assignment requirements — status
+
+From the assignment: *"Apply layered architecture: controllers -> services ->
+models / repositories ... use DTO objects in the controllers. Do not expose
+the models to the outside."*
+
+| Requirement | Status |
+|---|---|
+| DTOs in all controllers (no raw entities exposed) | ✅ Done — JPA, Mongo, Neo4j |
+| Layered architecture (controllers → services → repositories) | ✅ Done — all 35 controllers |
+| `/mongo/audit_log` admin-restriction | ⬜ **Open — the one remaining task** |
+
+## The open PR stack (4 PRs, stacked — merge bottom-up)
+
+| PR | Branch | Base | Scope |
+|---|---|---|---|
+| #109 | `feature/controller-dtos` | `main` | DTOs for 17 SQL/JPA controllers |
+| #111 | `feature/mongo-controller-dtos` | `feature/controller-dtos` | DTOs for 8 MongoDB controllers |
+| #112 | `feature/neo4j-controller-dtos` | `feature/mongo-controller-dtos` | DTOs for 10 Neo4j controllers |
+| #114 | `feature/service-layer` | `feature/neo4j-controller-dtos` | Service layer for all 35 controllers |
+
+**Merge order: #109 → #111 → #112 → #114.** Each PR's base retargets to `main`
+automatically as the one below it merges. Each PR shows only its own diff.
+
+Repo: `https://github.com/Luke3520/shift_happens.git`
+
+## Conventions established (follow these if extending the work)
+
+- **DTOs are Java `record`s** with a static `from(...)` factory and a
+  `toEntity()` method. Naming: JPA `XDto`, Mongo `XDocumentDto`, Neo4j
+  `XNodeDto` (distinct names avoid cross-package clashes).
+- **Sensitive fields:** `loginPassword` is write-only (`@JsonProperty(WRITE_ONLY)`);
+  `salaryAmount` is dropped from DTOs entirely.
+- **Services** are thin `@Service @RequiredArgsConstructor` delegates exposing
+  `findAll / findById / create / update / delete`. New services' `findById`
+  and `update` return `Optional`; the controller maps to the HTTP response.
+- No co-author / "Generated with Claude Code" trailers in commits or PRs.
+
+## THE REMAINING TASK — fix `/mongo/audit_log` authorization
+
+**Problem:** `SecurityConfig` (`auth/SecurityConfig.java`) secures all requests
+by URL. Its rule `/auditlogs/**` → `hasRole("ADMINISTRATOR")` restricts the JPA
+audit log to admins. But `AuditLogMongoController` is mapped at
+`/mongo/audit_log` — which that rule does NOT match. So the Mongo audit log is
+readable by any authenticated user (including a plain EMPLOYEE). Inconsistent
+with the JPA side.
+
+**Fix:** in `SecurityConfig.securityFilterChain`, add a matcher for the Mongo
+audit-log path next to the existing `/auditlogs/**` rule:
+
+```java
+.requestMatchers("/auditlogs/**").hasRole("ADMINISTRATOR")
+.requestMatchers("/mongo/audit_log/**").hasRole("ADMINISTRATOR")  // add this
+```
+
+(There is no Neo4j audit-log controller, so nothing is needed there.)
+
+**Do it as a new branch/PR** stacked on `feature/service-layer`
+(`feature/mongo-auditlog-auth` → base `feature/service-layer`). Verify with
+`mvn test` (expect 6/6 pass, `BUILD SUCCESS`).
+
+## Deliberately NOT done (defensible non-goals)
+
+- **`@PreAuthorize` on Mongo/Neo4j controllers** — redundant. `SecurityConfig`'s
+  filter chain already authenticates every request and requires ADMIN/MANAGER
+  for POST/PUT/PATCH/DELETE on `/**`. The JPA `@PreAuthorize` annotations are
+  belt-and-suspenders; replicating them adds no real access control.
+- **Per-row employee-scoping on Mongo/Neo4j** — the JPA side uses `AuthHelper`
+  so an EMPLOYEE sees only their own rows. Mongo/Neo4j lack this. Left as a
+  known limitation: those endpoints are parallel demo surfaces, not consumed
+  by the frontend.
+- **Consumer-driven / view-specific DTOs** — the 3 denormalised Mongo
+  aggregates are mirrored 1:1. Best practice would be smaller, use-case-shaped
+  DTOs, but there is no frontend consumer to design against. See
+  `dto-rationale.md`.

--- a/docs/dto-rationale.md
+++ b/docs/dto-rationale.md
@@ -106,10 +106,7 @@ Two details specific to Neo4j:
 
 ## Known follow-ups (out of scope here)
 
-- **Mongo and Neo4j controllers have no service layer** — they call
-  repositories directly, whereas the assignment asks for
-  `controllers -> services -> repositories`. Not addressed in this
-  DTO-focused change.
+- **Service layer** — added in a follow-up branch; see `docs/service-layer.md`.
 - **Mongo and Neo4j controllers have no `@PreAuthorize`** — they are
   unauthenticated, unlike the JPA controllers. A separate security concern.
 

--- a/docs/service-layer.md
+++ b/docs/service-layer.md
@@ -1,0 +1,44 @@
+# Service Layer — Rationale
+
+## Requirement
+
+> "Apply layered architecture: controllers -> services -> models / repositories."
+> — assignment brief
+
+## What was done
+
+Before this change only **5 of 17 JPA controllers** had a service; the Mongo
+and Neo4j controllers had none and called their repositories directly. Every
+controller now goes through a service:
+
+| Store | Controllers | Services added |
+|---|---|---|
+| JPA   | 17 | 12 (5 already existed) |
+| Mongo | 8  | 8 |
+| Neo4j | 10 | 9 (`ShiftSwapNeo4jService` already existed; extended) |
+
+The dependency chain is now uniformly `controller -> service -> repository`
+for all 35 controllers.
+
+## Design
+
+- **Thin delegating services.** Each service is `@Service @RequiredArgsConstructor`,
+  holds the repository, and exposes `findAll / findById / create / update /
+  delete`. No business logic was invented — adding any would be speculative.
+- **`findById` / `update` return `Optional`.** The service stays free of HTTP
+  concerns; the controller decides the HTTP response (404, empty body, etc.).
+  This follows the existing `LeaveRequestService.patch` precedent. The older
+  `DepartmentService` throws `ResponseStatusException` internally instead — a
+  minor pre-existing inconsistency, left untouched to keep this change surgical.
+- **Behaviour preserved.** Field-copy logic in `update` moved verbatim from the
+  controllers into the services; every endpoint's status codes are unchanged.
+- **Neo4j `ShiftSwap`.** The existing `ShiftSwapNeo4jService` was extended with
+  `findAll` / `findById` and the two Cypher candidate-queries, so the controller
+  no longer talks to `Neo4jClient` or the repository directly.
+
+## Known follow-ups (still out of scope)
+
+- **No `@PreAuthorize` on Mongo / Neo4j controllers** — a separate security
+  concern.
+- **`DepartmentService` style divergence** — older services throw from
+  `findById`; new ones return `Optional`. Could be aligned later.

--- a/src/main/java/dk/ek/shift_happens/auditlog/AuditLogController.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/AuditLogController.java
@@ -12,10 +12,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuditLogController {
 
-    private final AuditLogRepository auditLogRepository;
+    private final AuditLogService auditLogService;
 
     @GetMapping
     public List<AuditLogDto> getAuditLogs() {
-        return this.auditLogRepository.findAll().stream().map(AuditLogDto::from).toList();
+        return this.auditLogService.findAll().stream().map(AuditLogDto::from).toList();
     }
 }

--- a/src/main/java/dk/ek/shift_happens/auditlog/AuditLogService.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/AuditLogService.java
@@ -1,0 +1,17 @@
+package dk.ek.shift_happens.auditlog;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    public List<AuditLog> findAll() {
+        return auditLogRepository.findAll();
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuditLogMongoController {
 
-    private final AuditLogMongoRepository auditLogMongoRepository;
+    private final AuditLogMongoService auditLogMongoService;
 
     @GetMapping
     public List<AuditLogDocumentDto> getAll() {
-        return auditLogMongoRepository.findAll().stream().map(AuditLogDocumentDto::from).toList();
+        return auditLogMongoService.findAll().stream().map(AuditLogDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public AuditLogDocumentDto getById(@PathVariable String id) {
-        return auditLogMongoRepository.findById(id)
+        return auditLogMongoService.findById(id)
                 .map(AuditLogDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public AuditLogDocumentDto create(@RequestBody AuditLogDocumentDto auditLog) {
-        return AuditLogDocumentDto.from(auditLogMongoRepository.save(auditLog.toEntity()));
+        return AuditLogDocumentDto.from(auditLogMongoService.create(auditLog.toEntity()));
     }
 
     @PutMapping("/{id}")
     public AuditLogDocumentDto update(@PathVariable String id, @RequestBody AuditLogDocumentDto auditLog) {
-        if (!auditLogMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        AuditLogDocument entity = auditLog.toEntity();
-        entity.setId(id);
-        return AuditLogDocumentDto.from(auditLogMongoRepository.save(entity));
+        return auditLogMongoService.update(id, auditLog.toEntity())
+                .map(AuditLogDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!auditLogMongoRepository.existsById(id)) {
+        if (!auditLogMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        auditLogMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/auditlog/mongo/AuditLogMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.auditlog.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogMongoService {
+
+    private final AuditLogMongoRepository auditLogMongoRepository;
+
+    public List<AuditLogDocument> findAll() {
+        return auditLogMongoRepository.findAll();
+    }
+
+    public Optional<AuditLogDocument> findById(String id) {
+        return auditLogMongoRepository.findById(id);
+    }
+
+    public AuditLogDocument create(AuditLogDocument document) {
+        return auditLogMongoRepository.save(document);
+    }
+
+    public Optional<AuditLogDocument> update(String id, AuditLogDocument document) {
+        if (!auditLogMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(auditLogMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!auditLogMongoRepository.existsById(id)) {
+            return false;
+        }
+        auditLogMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DepartmentMongoController {
 
-    private final DepartmentMongoRepository departmentMongoRepository;
+    private final DepartmentMongoService departmentMongoService;
 
     @GetMapping
     public List<DepartmentDocumentDto> getAll() {
-        return departmentMongoRepository.findAll().stream().map(DepartmentDocumentDto::from).toList();
+        return departmentMongoService.findAll().stream().map(DepartmentDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public DepartmentDocumentDto getById(@PathVariable String id) {
-        return departmentMongoRepository.findById(id)
+        return departmentMongoService.findById(id)
                 .map(DepartmentDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public DepartmentDocumentDto create(@RequestBody DepartmentDocumentDto department) {
-        return DepartmentDocumentDto.from(departmentMongoRepository.save(department.toEntity()));
+        return DepartmentDocumentDto.from(departmentMongoService.create(department.toEntity()));
     }
 
     @PutMapping("/{id}")
     public DepartmentDocumentDto update(@PathVariable String id, @RequestBody DepartmentDocumentDto department) {
-        if (!departmentMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        DepartmentDocument entity = department.toEntity();
-        entity.setId(id);
-        return DepartmentDocumentDto.from(departmentMongoRepository.save(entity));
+        return departmentMongoService.update(id, department.toEntity())
+                .map(DepartmentDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!departmentMongoRepository.existsById(id)) {
+        if (!departmentMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        departmentMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/department/mongo/DepartmentMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.department.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentMongoService {
+
+    private final DepartmentMongoRepository departmentMongoRepository;
+
+    public List<DepartmentDocument> findAll() {
+        return departmentMongoRepository.findAll();
+    }
+
+    public Optional<DepartmentDocument> findById(String id) {
+        return departmentMongoRepository.findById(id);
+    }
+
+    public DepartmentDocument create(DepartmentDocument document) {
+        return departmentMongoRepository.save(document);
+    }
+
+    public Optional<DepartmentDocument> update(String id, DepartmentDocument document) {
+        if (!departmentMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(departmentMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!departmentMongoRepository.existsById(id)) {
+            return false;
+        }
+        departmentMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DepartmentNeo4jController {
 
-    private final DepartmentNeo4jRepository departmentNeo4jRepository;
+    private final DepartmentNeo4jService departmentNeo4jService;
 
     @GetMapping
     public List<DepartmentNodeDto> getAll() {
-        return departmentNeo4jRepository.findAll().stream().map(DepartmentNodeDto::from).toList();
+        return departmentNeo4jService.findAll().stream().map(DepartmentNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public DepartmentNodeDto getById(@PathVariable Long id) {
-        return departmentNeo4jRepository.findById(id)
+        return departmentNeo4jService.findById(id)
                 .map(DepartmentNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/department/neo4j/DepartmentNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.department.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentNeo4jService {
+
+    private final DepartmentNeo4jRepository departmentNeo4jRepository;
+
+    public List<DepartmentNode> findAll() {
+        return departmentNeo4jRepository.findAll();
+    }
+
+    public Optional<DepartmentNode> findById(Long id) {
+        return departmentNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmployeeMongoController {
 
-    private final EmployeeMongoRepository employeeMongoRepository;
+    private final EmployeeMongoService employeeMongoService;
 
     @GetMapping
     public List<EmployeeDocumentDto> getAll() {
-        return employeeMongoRepository.findAll().stream().map(EmployeeDocumentDto::from).toList();
+        return employeeMongoService.findAll().stream().map(EmployeeDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public EmployeeDocumentDto getById(@PathVariable Integer id) {
-        return employeeMongoRepository.findById(id)
+        return employeeMongoService.findById(id)
                 .map(EmployeeDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public EmployeeDocumentDto create(@RequestBody EmployeeDocumentDto employee) {
-        return EmployeeDocumentDto.from(employeeMongoRepository.save(employee.toEntity()));
+        return EmployeeDocumentDto.from(employeeMongoService.create(employee.toEntity()));
     }
 
     @PutMapping("/{id}")
     public EmployeeDocumentDto update(@PathVariable Integer id, @RequestBody EmployeeDocumentDto employee) {
-        if (!employeeMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        EmployeeDocument entity = employee.toEntity();
-        entity.setEmployeeId(id);
-        return EmployeeDocumentDto.from(employeeMongoRepository.save(entity));
+        return employeeMongoService.update(id, employee.toEntity())
+                .map(EmployeeDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        if (!employeeMongoRepository.existsById(id)) {
+        if (!employeeMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        employeeMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.employee.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeMongoService {
+
+    private final EmployeeMongoRepository employeeMongoRepository;
+
+    public List<EmployeeDocument> findAll() {
+        return employeeMongoRepository.findAll();
+    }
+
+    public Optional<EmployeeDocument> findById(Integer id) {
+        return employeeMongoRepository.findById(id);
+    }
+
+    public EmployeeDocument create(EmployeeDocument document) {
+        return employeeMongoRepository.save(document);
+    }
+
+    public Optional<EmployeeDocument> update(Integer id, EmployeeDocument document) {
+        if (!employeeMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setEmployeeId(id);
+        return Optional.of(employeeMongoRepository.save(document));
+    }
+
+    public boolean delete(Integer id) {
+        if (!employeeMongoRepository.existsById(id)) {
+            return false;
+        }
+        employeeMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmployeeNeo4jController {
 
-    private final EmployeeNeo4jRepository employeeNeo4jRepository;
+    private final EmployeeNeo4jService employeeNeo4jService;
 
     @GetMapping
     public List<EmployeeNodeDto> getAll() {
-        return employeeNeo4jRepository.findAll().stream().map(EmployeeNodeDto::from).toList();
+        return employeeNeo4jService.findAll().stream().map(EmployeeNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public EmployeeNodeDto getById(@PathVariable Long id) {
-        return employeeNeo4jRepository.findById(id)
+        return employeeNeo4jService.findById(id)
                 .map(EmployeeNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.employee.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeNeo4jService {
+
+    private final EmployeeNeo4jRepository employeeNeo4jRepository;
+
+    public List<EmployeeNode> findAll() {
+        return employeeNeo4jRepository.findAll();
+    }
+
+    public Optional<EmployeeNode> findById(Long id) {
+        return employeeNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractController.java
+++ b/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractController.java
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmployeeContractController {
 
-    private final EmployeeContractRepository employeeContractRepository;
+    private final EmployeeContractService employeeContractService;
     private final AuthHelper authHelper;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<EmployeeContractDto> getAll(Authentication auth) {
         List<EmployeeContract> contracts = authHelper.isEmployee(auth)
-                ? employeeContractRepository.findByEmployeeId(authHelper.currentEmployeeId(auth))
-                : employeeContractRepository.findAll();
+                ? employeeContractService.findByEmployeeId(authHelper.currentEmployeeId(auth))
+                : employeeContractService.findAll();
         return contracts.stream().map(EmployeeContractDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public EmployeeContractDto getById(@PathVariable Integer id, Authentication auth) {
-        EmployeeContract contract = employeeContractRepository.findById(id)
+        EmployeeContract contract = employeeContractService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
         if (authHelper.isEmployee(auth)
@@ -44,29 +44,21 @@ public class EmployeeContractController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public EmployeeContractDto create(@RequestBody EmployeeContractDto contract) {
-        return EmployeeContractDto.from(employeeContractRepository.save(contract.toEntity()));
+        return EmployeeContractDto.from(employeeContractService.create(contract.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public EmployeeContractDto update(@PathVariable Integer id, @RequestBody EmployeeContractDto details) {
-        EmployeeContract existing = employeeContractRepository.findById(id)
+        return employeeContractService.update(id, details.toEntity())
+                .map(EmployeeContractDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setEmployeeId(details.employeeId());
-        existing.setDepartmentId(details.departmentId());
-        existing.setContractType(details.contractType());
-        existing.setStartDate(details.startDate());
-        existing.setEndDate(details.endDate());
-        existing.setWeeklyHours(details.weeklyHours());
-        // salaryAmount is not part of the DTO and is left untouched on update.
-        existing.setIsActive(details.isActive());
-        return EmployeeContractDto.from(employeeContractRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        employeeContractRepository.deleteById(id);
+        employeeContractService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractService.java
+++ b/src/main/java/dk/ek/shift_happens/employeecontract/EmployeeContractService.java
@@ -1,0 +1,48 @@
+package dk.ek.shift_happens.employeecontract;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeContractService {
+
+    private final EmployeeContractRepository employeeContractRepository;
+
+    public List<EmployeeContract> findAll() {
+        return employeeContractRepository.findAll();
+    }
+
+    public List<EmployeeContract> findByEmployeeId(Integer employeeId) {
+        return employeeContractRepository.findByEmployeeId(employeeId);
+    }
+
+    public Optional<EmployeeContract> findById(Integer id) {
+        return employeeContractRepository.findById(id);
+    }
+
+    public EmployeeContract create(EmployeeContract contract) {
+        return employeeContractRepository.save(contract);
+    }
+
+    public Optional<EmployeeContract> update(Integer id, EmployeeContract updates) {
+        return employeeContractRepository.findById(id).map(existing -> {
+            existing.setEmployeeId(updates.getEmployeeId());
+            existing.setDepartmentId(updates.getDepartmentId());
+            existing.setContractType(updates.getContractType());
+            existing.setStartDate(updates.getStartDate());
+            existing.setEndDate(updates.getEndDate());
+            existing.setWeeklyHours(updates.getWeeklyHours());
+            // salaryAmount is intentionally not updated — it is not part of the DTO.
+            existing.setIsActive(updates.getIsActive());
+            return employeeContractRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        employeeContractRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/JobRoleController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/JobRoleController.java
@@ -13,18 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JobRoleController {
 
-    private final JobRoleRepository jobRoleRepository;
+    private final JobRoleService jobRoleService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<JobRoleDto> getAll() {
-        return jobRoleRepository.findAll().stream().map(JobRoleDto::from).toList();
+        return jobRoleService.findAll().stream().map(JobRoleDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public JobRoleDto getById(@PathVariable Integer id) {
-        return jobRoleRepository.findById(id)
+        return jobRoleService.findById(id)
                 .map(JobRoleDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -33,24 +33,21 @@ public class JobRoleController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public JobRoleDto create(@RequestBody JobRoleDto jobRole) {
-        return JobRoleDto.from(jobRoleRepository.save(jobRole.toEntity()));
+        return JobRoleDto.from(jobRoleService.create(jobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public JobRoleDto update(@PathVariable Integer id, @RequestBody JobRoleDto details) {
-        JobRole existing = jobRoleRepository.findById(id)
+        return jobRoleService.update(id, details.toEntity())
+                .map(JobRoleDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setRoleName(details.roleName());
-        existing.setJobRoleDescription(details.jobRoleDescription());
-        existing.setIsCertificationRequired(details.isCertificationRequired());
-        return JobRoleDto.from(jobRoleRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        jobRoleRepository.deleteById(id);
+        jobRoleService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/jobrole/JobRoleService.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/JobRoleService.java
@@ -1,0 +1,39 @@
+package dk.ek.shift_happens.jobrole;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobRoleService {
+
+    private final JobRoleRepository jobRoleRepository;
+
+    public List<JobRole> findAll() {
+        return jobRoleRepository.findAll();
+    }
+
+    public Optional<JobRole> findById(Integer id) {
+        return jobRoleRepository.findById(id);
+    }
+
+    public JobRole create(JobRole jobRole) {
+        return jobRoleRepository.save(jobRole);
+    }
+
+    public Optional<JobRole> update(Integer id, JobRole updates) {
+        return jobRoleRepository.findById(id).map(existing -> {
+            existing.setRoleName(updates.getRoleName());
+            existing.setJobRoleDescription(updates.getJobRoleDescription());
+            existing.setIsCertificationRequired(updates.getIsCertificationRequired());
+            return jobRoleRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        jobRoleRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JobRoleMongoController {
 
-    private final JobRoleMongoRepository jobRoleMongoRepository;
+    private final JobRoleMongoService jobRoleMongoService;
 
     @GetMapping
     public List<JobRoleDocumentDto> getAll() {
-        return jobRoleMongoRepository.findAll().stream().map(JobRoleDocumentDto::from).toList();
+        return jobRoleMongoService.findAll().stream().map(JobRoleDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public JobRoleDocumentDto getById(@PathVariable String id) {
-        return jobRoleMongoRepository.findById(id)
+        return jobRoleMongoService.findById(id)
                 .map(JobRoleDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public JobRoleDocumentDto create(@RequestBody JobRoleDocumentDto jobRole) {
-        return JobRoleDocumentDto.from(jobRoleMongoRepository.save(jobRole.toEntity()));
+        return JobRoleDocumentDto.from(jobRoleMongoService.create(jobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
     public JobRoleDocumentDto update(@PathVariable String id, @RequestBody JobRoleDocumentDto jobRole) {
-        if (!jobRoleMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        JobRoleDocument entity = jobRole.toEntity();
-        entity.setId(id);
-        return JobRoleDocumentDto.from(jobRoleMongoRepository.save(entity));
+        return jobRoleMongoService.update(id, jobRole.toEntity())
+                .map(JobRoleDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!jobRoleMongoRepository.existsById(id)) {
+        if (!jobRoleMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        jobRoleMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/mongo/JobRoleMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.jobrole.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobRoleMongoService {
+
+    private final JobRoleMongoRepository jobRoleMongoRepository;
+
+    public List<JobRoleDocument> findAll() {
+        return jobRoleMongoRepository.findAll();
+    }
+
+    public Optional<JobRoleDocument> findById(String id) {
+        return jobRoleMongoRepository.findById(id);
+    }
+
+    public JobRoleDocument create(JobRoleDocument document) {
+        return jobRoleMongoRepository.save(document);
+    }
+
+    public Optional<JobRoleDocument> update(String id, JobRoleDocument document) {
+        if (!jobRoleMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(jobRoleMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!jobRoleMongoRepository.existsById(id)) {
+            return false;
+        }
+        jobRoleMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JobRoleNeo4jController {
 
-    private final JobRoleNeo4jRepository jobRoleNeo4jRepository;
+    private final JobRoleNeo4jService jobRoleNeo4jService;
 
     @GetMapping
     public List<JobRoleNodeDto> getAll() {
-        return jobRoleNeo4jRepository.findAll().stream().map(JobRoleNodeDto::from).toList();
+        return jobRoleNeo4jService.findAll().stream().map(JobRoleNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public JobRoleNodeDto getById(@PathVariable Long id) {
-        return jobRoleNeo4jRepository.findById(id)
+        return jobRoleNeo4jService.findById(id)
                 .map(JobRoleNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/jobrole/neo4j/JobRoleNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.jobrole.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JobRoleNeo4jService {
+
+    private final JobRoleNeo4jRepository jobRoleNeo4jRepository;
+
+    public List<JobRoleNode> findAll() {
+        return jobRoleNeo4jRepository.findAll();
+    }
+
+    public Optional<JobRoleNode> findById(Long id) {
+        return jobRoleNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveApprovalNeo4jController {
 
-    private final LeaveApprovalNeo4jRepository leaveApprovalNeo4jRepository;
+    private final LeaveApprovalNeo4jService leaveApprovalNeo4jService;
 
     @GetMapping
     public List<LeaveApprovalNodeDto> getAll() {
-        return leaveApprovalNeo4jRepository.findAll().stream().map(LeaveApprovalNodeDto::from).toList();
+        return leaveApprovalNeo4jService.findAll().stream().map(LeaveApprovalNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveApprovalNodeDto getById(@PathVariable Long id) {
-        return leaveApprovalNeo4jRepository.findById(id)
+        return leaveApprovalNeo4jService.findById(id)
                 .map(LeaveApprovalNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveApprovalNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveApprovalNodeDto create(@RequestBody LeaveApprovalNodeDto node) {
-        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jRepository.save(node.toEntity()));
+        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveApprovalNodeDto update(@PathVariable Long id, @RequestBody LeaveApprovalNodeDto node) {
-        if (!leaveApprovalNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveApprovalNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveApprovalNodeDto.from(leaveApprovalNeo4jRepository.save(entity));
+        return leaveApprovalNeo4jService.update(id, node.toEntity())
+                .map(LeaveApprovalNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveApprovalNeo4jRepository.existsById(id)) {
+        if (!leaveApprovalNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveApprovalNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leaveapproval/neo4j/LeaveApprovalNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaveapproval.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveApprovalNeo4jService {
+
+    private final LeaveApprovalNeo4jRepository leaveApprovalNeo4jRepository;
+
+    public List<LeaveApprovalNode> findAll() {
+        return leaveApprovalNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveApprovalNode> findById(Long id) {
+        return leaveApprovalNeo4jRepository.findById(id);
+    }
+
+    public LeaveApprovalNode create(LeaveApprovalNode node) {
+        return leaveApprovalNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveApprovalNode> update(Long id, LeaveApprovalNode node) {
+        if (!leaveApprovalNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveApprovalNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveApprovalNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveApprovalNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerController.java
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveLedgerController {
 
-    private final LeaveLedgerRepository leaveLedgerRepository;
+    private final LeaveLedgerService leaveLedgerService;
     private final AuthHelper authHelper;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<LeaveLedgerDto> getAll(Authentication auth) {
         List<LeaveLedger> ledgers = authHelper.isEmployee(auth)
-                ? leaveLedgerRepository.findByEmployeeId(authHelper.currentEmployeeId(auth))
-                : leaveLedgerRepository.findAll();
+                ? leaveLedgerService.findByEmployeeId(authHelper.currentEmployeeId(auth))
+                : leaveLedgerService.findAll();
         return ledgers.stream().map(LeaveLedgerDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public LeaveLedgerDto getById(@PathVariable Integer id, Authentication auth) {
-        LeaveLedger ledger = leaveLedgerRepository.findById(id)
+        LeaveLedger ledger = leaveLedgerService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
         if (authHelper.isEmployee(auth)
@@ -44,28 +44,21 @@ public class LeaveLedgerController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveLedgerDto create(@RequestBody LeaveLedgerDto ledger) {
-        return LeaveLedgerDto.from(leaveLedgerRepository.save(ledger.toEntity()));
+        return LeaveLedgerDto.from(leaveLedgerService.create(ledger.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public LeaveLedgerDto update(@PathVariable Integer id, @RequestBody LeaveLedgerDto details) {
-        LeaveLedger existing = leaveLedgerRepository.findById(id)
+        return leaveLedgerService.update(id, details.toEntity())
+                .map(LeaveLedgerDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setEmployeeId(details.employeeId());
-        existing.setLeaveTypeId(details.leaveTypeId());
-        existing.setChangeAmountDays(details.changeAmountDays());
-        existing.setTransactionType(details.transactionType());
-        existing.setReferenceEntityType(details.referenceEntityType());
-        existing.setReferenceEntityId(details.referenceEntityId());
-        existing.setTransactionDatetime(details.transactionDatetime());
-        return LeaveLedgerDto.from(leaveLedgerRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        leaveLedgerRepository.deleteById(id);
+        leaveLedgerService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerService.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/LeaveLedgerService.java
@@ -1,0 +1,47 @@
+package dk.ek.shift_happens.leaveledger;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveLedgerService {
+
+    private final LeaveLedgerRepository leaveLedgerRepository;
+
+    public List<LeaveLedger> findAll() {
+        return leaveLedgerRepository.findAll();
+    }
+
+    public List<LeaveLedger> findByEmployeeId(Integer employeeId) {
+        return leaveLedgerRepository.findByEmployeeId(employeeId);
+    }
+
+    public Optional<LeaveLedger> findById(Integer id) {
+        return leaveLedgerRepository.findById(id);
+    }
+
+    public LeaveLedger create(LeaveLedger leaveLedger) {
+        return leaveLedgerRepository.save(leaveLedger);
+    }
+
+    public Optional<LeaveLedger> update(Integer id, LeaveLedger updates) {
+        return leaveLedgerRepository.findById(id).map(existing -> {
+            existing.setEmployeeId(updates.getEmployeeId());
+            existing.setLeaveTypeId(updates.getLeaveTypeId());
+            existing.setChangeAmountDays(updates.getChangeAmountDays());
+            existing.setTransactionType(updates.getTransactionType());
+            existing.setReferenceEntityType(updates.getReferenceEntityType());
+            existing.setReferenceEntityId(updates.getReferenceEntityId());
+            existing.setTransactionDatetime(updates.getTransactionDatetime());
+            return leaveLedgerRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        leaveLedgerRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveLedgerNeo4jController {
 
-    private final LeaveLedgerNeo4jRepository leaveLedgerNeo4jRepository;
+    private final LeaveLedgerNeo4jService leaveLedgerNeo4jService;
 
     @GetMapping
     public List<LeaveLedgerNodeDto> getAll() {
-        return leaveLedgerNeo4jRepository.findAll().stream().map(LeaveLedgerNodeDto::from).toList();
+        return leaveLedgerNeo4jService.findAll().stream().map(LeaveLedgerNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveLedgerNodeDto getById(@PathVariable Long id) {
-        return leaveLedgerNeo4jRepository.findById(id)
+        return leaveLedgerNeo4jService.findById(id)
                 .map(LeaveLedgerNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveLedgerNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveLedgerNodeDto create(@RequestBody LeaveLedgerNodeDto node) {
-        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jRepository.save(node.toEntity()));
+        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveLedgerNodeDto update(@PathVariable Long id, @RequestBody LeaveLedgerNodeDto node) {
-        if (!leaveLedgerNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveLedgerNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveLedgerNodeDto.from(leaveLedgerNeo4jRepository.save(entity));
+        return leaveLedgerNeo4jService.update(id, node.toEntity())
+                .map(LeaveLedgerNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveLedgerNeo4jRepository.existsById(id)) {
+        if (!leaveLedgerNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveLedgerNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leaveledger/neo4j/LeaveLedgerNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaveledger.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveLedgerNeo4jService {
+
+    private final LeaveLedgerNeo4jRepository leaveLedgerNeo4jRepository;
+
+    public List<LeaveLedgerNode> findAll() {
+        return leaveLedgerNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveLedgerNode> findById(Long id) {
+        return leaveLedgerNeo4jRepository.findById(id);
+    }
+
+    public LeaveLedgerNode create(LeaveLedgerNode node) {
+        return leaveLedgerNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveLedgerNode> update(Long id, LeaveLedgerNode node) {
+        if (!leaveLedgerNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveLedgerNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveLedgerNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveLedgerNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveMongoController {
 
-    private final LeaveMongoRepository leaveMongoRepository;
+    private final LeaveMongoService leaveMongoService;
 
     @GetMapping
     public List<LeaveDocumentDto> getAll() {
-        return leaveMongoRepository.findAll().stream().map(LeaveDocumentDto::from).toList();
+        return leaveMongoService.findAll().stream().map(LeaveDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveDocumentDto getById(@PathVariable String id) {
-        return leaveMongoRepository.findById(id)
+        return leaveMongoService.findById(id)
                 .map(LeaveDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public LeaveDocumentDto create(@RequestBody LeaveDocumentDto leave) {
-        return LeaveDocumentDto.from(leaveMongoRepository.save(leave.toEntity()));
+        return LeaveDocumentDto.from(leaveMongoService.create(leave.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveDocumentDto update(@PathVariable String id, @RequestBody LeaveDocumentDto leave) {
-        if (!leaveMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveDocument entity = leave.toEntity();
-        entity.setId(id);
-        return LeaveDocumentDto.from(leaveMongoRepository.save(entity));
+        return leaveMongoService.update(id, leave.toEntity())
+                .map(LeaveDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!leaveMongoRepository.existsById(id)) {
+        if (!leaveMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/mongo/LeaveMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaverequest.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveMongoService {
+
+    private final LeaveMongoRepository leaveMongoRepository;
+
+    public List<LeaveDocument> findAll() {
+        return leaveMongoRepository.findAll();
+    }
+
+    public Optional<LeaveDocument> findById(String id) {
+        return leaveMongoRepository.findById(id);
+    }
+
+    public LeaveDocument create(LeaveDocument document) {
+        return leaveMongoRepository.save(document);
+    }
+
+    public Optional<LeaveDocument> update(String id, LeaveDocument document) {
+        if (!leaveMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(leaveMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!leaveMongoRepository.existsById(id)) {
+            return false;
+        }
+        leaveMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveRequestNeo4jController {
 
-    private final LeaveRequestNeo4jRepository leaveRequestNeo4jRepository;
+    private final LeaveRequestNeo4jService leaveRequestNeo4jService;
 
     @GetMapping
     public List<LeaveRequestNodeDto> getAll() {
-        return leaveRequestNeo4jRepository.findAll().stream().map(LeaveRequestNodeDto::from).toList();
+        return leaveRequestNeo4jService.findAll().stream().map(LeaveRequestNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveRequestNodeDto getById(@PathVariable Long id) {
-        return leaveRequestNeo4jRepository.findById(id)
+        return leaveRequestNeo4jService.findById(id)
                 .map(LeaveRequestNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveRequestNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveRequestNodeDto create(@RequestBody LeaveRequestNodeDto node) {
-        return LeaveRequestNodeDto.from(leaveRequestNeo4jRepository.save(node.toEntity()));
+        return LeaveRequestNodeDto.from(leaveRequestNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveRequestNodeDto update(@PathVariable Long id, @RequestBody LeaveRequestNodeDto node) {
-        if (!leaveRequestNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveRequestNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveRequestNodeDto.from(leaveRequestNeo4jRepository.save(entity));
+        return leaveRequestNeo4jService.update(id, node.toEntity())
+                .map(LeaveRequestNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveRequestNeo4jRepository.existsById(id)) {
+        if (!leaveRequestNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveRequestNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leaverequest/neo4j/LeaveRequestNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leaverequest.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveRequestNeo4jService {
+
+    private final LeaveRequestNeo4jRepository leaveRequestNeo4jRepository;
+
+    public List<LeaveRequestNode> findAll() {
+        return leaveRequestNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveRequestNode> findById(Long id) {
+        return leaveRequestNeo4jRepository.findById(id);
+    }
+
+    public LeaveRequestNode create(LeaveRequestNode node) {
+        return leaveRequestNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveRequestNode> update(Long id, LeaveRequestNode node) {
+        if (!leaveRequestNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveRequestNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveRequestNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveRequestNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeController.java
@@ -13,18 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveTypeController {
 
-    private final LeaveTypeRepository leaveTypeRepository;
+    private final LeaveTypeService leaveTypeService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<LeaveTypeDto> getAll() {
-        return leaveTypeRepository.findAll().stream().map(LeaveTypeDto::from).toList();
+        return leaveTypeService.findAll().stream().map(LeaveTypeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public LeaveTypeDto getById(@PathVariable Integer id) {
-        return leaveTypeRepository.findById(id)
+        return leaveTypeService.findById(id)
                 .map(LeaveTypeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -33,25 +33,21 @@ public class LeaveTypeController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveTypeDto create(@RequestBody LeaveTypeDto leaveType) {
-        return LeaveTypeDto.from(leaveTypeRepository.save(leaveType.toEntity()));
+        return LeaveTypeDto.from(leaveTypeService.create(leaveType.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public LeaveTypeDto update(@PathVariable Integer id, @RequestBody LeaveTypeDto details) {
-        LeaveType existing = leaveTypeRepository.findById(id)
+        return leaveTypeService.update(id, details.toEntity())
+                .map(LeaveTypeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setLeaveTypeName(details.leaveTypeName());
-        existing.setLeaveTypeDescription(details.leaveTypeDescription());
-        existing.setRequiresApproval(details.requiresApproval());
-        existing.setIsPaidLeave(details.isPaidLeave());
-        return LeaveTypeDto.from(leaveTypeRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        leaveTypeRepository.deleteById(id);
+        leaveTypeService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeService.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/LeaveTypeService.java
@@ -1,0 +1,40 @@
+package dk.ek.shift_happens.leavetype;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveTypeService {
+
+    private final LeaveTypeRepository leaveTypeRepository;
+
+    public List<LeaveType> findAll() {
+        return leaveTypeRepository.findAll();
+    }
+
+    public Optional<LeaveType> findById(Integer id) {
+        return leaveTypeRepository.findById(id);
+    }
+
+    public LeaveType create(LeaveType leaveType) {
+        return leaveTypeRepository.save(leaveType);
+    }
+
+    public Optional<LeaveType> update(Integer id, LeaveType updates) {
+        return leaveTypeRepository.findById(id).map(existing -> {
+            existing.setLeaveTypeName(updates.getLeaveTypeName());
+            existing.setLeaveTypeDescription(updates.getLeaveTypeDescription());
+            existing.setRequiresApproval(updates.getRequiresApproval());
+            existing.setIsPaidLeave(updates.getIsPaidLeave());
+            return leaveTypeRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        leaveTypeRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveTypeMongoController {
 
-    private final LeaveTypeMongoRepository leaveTypeMongoRepository;
+    private final LeaveTypeMongoService leaveTypeMongoService;
 
     @GetMapping
     public List<LeaveTypeDocumentDto> getAll() {
-        return leaveTypeMongoRepository.findAll().stream().map(LeaveTypeDocumentDto::from).toList();
+        return leaveTypeMongoService.findAll().stream().map(LeaveTypeDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveTypeDocumentDto getById(@PathVariable String id) {
-        return leaveTypeMongoRepository.findById(id)
+        return leaveTypeMongoService.findById(id)
                 .map(LeaveTypeDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public LeaveTypeDocumentDto create(@RequestBody LeaveTypeDocumentDto leaveType) {
-        return LeaveTypeDocumentDto.from(leaveTypeMongoRepository.save(leaveType.toEntity()));
+        return LeaveTypeDocumentDto.from(leaveTypeMongoService.create(leaveType.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveTypeDocumentDto update(@PathVariable String id, @RequestBody LeaveTypeDocumentDto leaveType) {
-        if (!leaveTypeMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveTypeDocument entity = leaveType.toEntity();
-        entity.setId(id);
-        return LeaveTypeDocumentDto.from(leaveTypeMongoRepository.save(entity));
+        return leaveTypeMongoService.update(id, leaveType.toEntity())
+                .map(LeaveTypeDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!leaveTypeMongoRepository.existsById(id)) {
+        if (!leaveTypeMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveTypeMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/mongo/LeaveTypeMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leavetype.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveTypeMongoService {
+
+    private final LeaveTypeMongoRepository leaveTypeMongoRepository;
+
+    public List<LeaveTypeDocument> findAll() {
+        return leaveTypeMongoRepository.findAll();
+    }
+
+    public Optional<LeaveTypeDocument> findById(String id) {
+        return leaveTypeMongoRepository.findById(id);
+    }
+
+    public LeaveTypeDocument create(LeaveTypeDocument document) {
+        return leaveTypeMongoRepository.save(document);
+    }
+
+    public Optional<LeaveTypeDocument> update(String id, LeaveTypeDocument document) {
+        if (!leaveTypeMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(leaveTypeMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!leaveTypeMongoRepository.existsById(id)) {
+            return false;
+        }
+        leaveTypeMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LeaveTypeNeo4jController {
 
-    private final LeaveTypeNeo4jRepository leaveTypeNeo4jRepository;
+    private final LeaveTypeNeo4jService leaveTypeNeo4jService;
 
     @GetMapping
     public List<LeaveTypeNodeDto> getAll() {
-        return leaveTypeNeo4jRepository.findAll().stream().map(LeaveTypeNodeDto::from).toList();
+        return leaveTypeNeo4jService.findAll().stream().map(LeaveTypeNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public LeaveTypeNodeDto getById(@PathVariable Long id) {
-        return leaveTypeNeo4jRepository.findById(id)
+        return leaveTypeNeo4jService.findById(id)
                 .map(LeaveTypeNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -29,25 +29,21 @@ public class LeaveTypeNeo4jController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public LeaveTypeNodeDto create(@RequestBody LeaveTypeNodeDto node) {
-        return LeaveTypeNodeDto.from(leaveTypeNeo4jRepository.save(node.toEntity()));
+        return LeaveTypeNodeDto.from(leaveTypeNeo4jService.create(node.toEntity()));
     }
 
     @PutMapping("/{id}")
     public LeaveTypeNodeDto update(@PathVariable Long id, @RequestBody LeaveTypeNodeDto node) {
-        if (!leaveTypeNeo4jRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        LeaveTypeNode entity = node.toEntity();
-        entity.setId(id);
-        return LeaveTypeNodeDto.from(leaveTypeNeo4jRepository.save(entity));
+        return leaveTypeNeo4jService.update(id, node.toEntity())
+                .map(LeaveTypeNodeDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        if (!leaveTypeNeo4jRepository.existsById(id)) {
+        if (!leaveTypeNeo4jService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        leaveTypeNeo4jRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/leavetype/neo4j/LeaveTypeNeo4jService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.leavetype.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveTypeNeo4jService {
+
+    private final LeaveTypeNeo4jRepository leaveTypeNeo4jRepository;
+
+    public List<LeaveTypeNode> findAll() {
+        return leaveTypeNeo4jRepository.findAll();
+    }
+
+    public Optional<LeaveTypeNode> findById(Long id) {
+        return leaveTypeNeo4jRepository.findById(id);
+    }
+
+    public LeaveTypeNode create(LeaveTypeNode node) {
+        return leaveTypeNeo4jRepository.save(node);
+    }
+
+    public Optional<LeaveTypeNode> update(Long id, LeaveTypeNode node) {
+        if (!leaveTypeNeo4jRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        node.setId(id);
+        return Optional.of(leaveTypeNeo4jRepository.save(node));
+    }
+
+    public boolean delete(Long id) {
+        if (!leaveTypeNeo4jRepository.existsById(id)) {
+            return false;
+        }
+        leaveTypeNeo4jRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/ShiftController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/ShiftController.java
@@ -12,42 +12,37 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftController {
 
-    private final ShiftRepository shiftRepository;
+    private final ShiftService shiftService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<ShiftDto> getShifts() {
-        return this.shiftRepository.findAll().stream().map(ShiftDto::from).toList();
+        return this.shiftService.findAll().stream().map(ShiftDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public Optional<ShiftDto> getShiftById(@PathVariable Integer id) {
-        return this.shiftRepository.findById(id).map(ShiftDto::from);
+        return this.shiftService.findById(id).map(ShiftDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftDto createShift(@RequestBody ShiftDto shift) {
-        return ShiftDto.from(this.shiftRepository.save(shift.toEntity()));
+        return ShiftDto.from(this.shiftService.create(shift.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftDto updateShift(@PathVariable Integer id, @RequestBody ShiftDto shiftDetails) {
-        Shift shift = this.shiftRepository.findById(id).orElseThrow();
-        shift.setDepartmentId(shiftDetails.departmentId());
-        shift.setWorkLocationId(shiftDetails.workLocationId());
-        shift.setShiftName(shiftDetails.shiftName());
-        shift.setStartDatetime(shiftDetails.startDatetime());
-        shift.setEndDatetime(shiftDetails.endDatetime());
-        shift.setShiftStatus(shiftDetails.shiftStatus());
-        return ShiftDto.from(this.shiftRepository.save(shift));
+        return this.shiftService.update(id, shiftDetails.toEntity())
+                .map(ShiftDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShift(@PathVariable Integer id) {
-        this.shiftRepository.deleteById(id);
+        this.shiftService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shift/ShiftService.java
+++ b/src/main/java/dk/ek/shift_happens/shift/ShiftService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.shift;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftService {
+
+    private final ShiftRepository shiftRepository;
+
+    public List<Shift> findAll() {
+        return shiftRepository.findAll();
+    }
+
+    public Optional<Shift> findById(Integer id) {
+        return shiftRepository.findById(id);
+    }
+
+    public Shift create(Shift shift) {
+        return shiftRepository.save(shift);
+    }
+
+    public Optional<Shift> update(Integer id, Shift updates) {
+        return shiftRepository.findById(id).map(existing -> {
+            existing.setDepartmentId(updates.getDepartmentId());
+            existing.setWorkLocationId(updates.getWorkLocationId());
+            existing.setShiftName(updates.getShiftName());
+            existing.setStartDatetime(updates.getStartDatetime());
+            existing.setEndDatetime(updates.getEndDatetime());
+            existing.setShiftStatus(updates.getShiftStatus());
+            return shiftRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftMongoController {
 
-    private final ShiftMongoRepository shiftMongoRepository;
+    private final ShiftMongoService shiftMongoService;
 
     @GetMapping
     public List<ShiftDocumentDto> getAll() {
-        return shiftMongoRepository.findAll().stream().map(ShiftDocumentDto::from).toList();
+        return shiftMongoService.findAll().stream().map(ShiftDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public ShiftDocumentDto getById(@PathVariable Integer id) {
-        return shiftMongoRepository.findById(id)
+        return shiftMongoService.findById(id)
                 .map(ShiftDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public ShiftDocumentDto create(@RequestBody ShiftDocumentDto shift) {
-        return ShiftDocumentDto.from(shiftMongoRepository.save(shift.toEntity()));
+        return ShiftDocumentDto.from(shiftMongoService.create(shift.toEntity()));
     }
 
     @PutMapping("/{id}")
     public ShiftDocumentDto update(@PathVariable Integer id, @RequestBody ShiftDocumentDto shift) {
-        if (!shiftMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        ShiftDocument entity = shift.toEntity();
-        entity.setShiftId(id);
-        return ShiftDocumentDto.from(shiftMongoRepository.save(entity));
+        return shiftMongoService.update(id, shift.toEntity())
+                .map(ShiftDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        if (!shiftMongoRepository.existsById(id)) {
+        if (!shiftMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        shiftMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/shift/mongo/ShiftMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.shift.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftMongoService {
+
+    private final ShiftMongoRepository shiftMongoRepository;
+
+    public List<ShiftDocument> findAll() {
+        return shiftMongoRepository.findAll();
+    }
+
+    public Optional<ShiftDocument> findById(Integer id) {
+        return shiftMongoRepository.findById(id);
+    }
+
+    public ShiftDocument create(ShiftDocument document) {
+        return shiftMongoRepository.save(document);
+    }
+
+    public Optional<ShiftDocument> update(Integer id, ShiftDocument document) {
+        if (!shiftMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setShiftId(id);
+        return Optional.of(shiftMongoRepository.save(document));
+    }
+
+    public boolean delete(Integer id) {
+        if (!shiftMongoRepository.existsById(id)) {
+            return false;
+        }
+        shiftMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftNeo4jController {
 
-    private final ShiftNeo4jRepository shiftNeo4jRepository;
+    private final ShiftNeo4jService shiftNeo4jService;
 
     @GetMapping
     public List<ShiftNodeDto> getAll() {
-        return shiftNeo4jRepository.findAll().stream().map(ShiftNodeDto::from).toList();
+        return shiftNeo4jService.findAll().stream().map(ShiftNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public ShiftNodeDto getById(@PathVariable Long id) {
-        return shiftNeo4jRepository.findById(id)
+        return shiftNeo4jService.findById(id)
                 .map(ShiftNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/shift/neo4j/ShiftNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.shift.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftNeo4jService {
+
+    private final ShiftNeo4jRepository shiftNeo4jRepository;
+
+    public List<ShiftNode> findAll() {
+        return shiftNeo4jRepository.findAll();
+    }
+
+    public Optional<ShiftNode> findById(Long id) {
+        return shiftNeo4jRepository.findById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalController.java
@@ -12,41 +12,37 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftApprovalController {
 
-    private final ShiftApprovalRepository shiftApprovalRepository;
+    private final ShiftApprovalService shiftApprovalService;
 
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public List<ShiftApprovalDto> getShiftApprovals() {
-        return this.shiftApprovalRepository.findAll().stream().map(ShiftApprovalDto::from).toList();
+        return this.shiftApprovalService.findAll().stream().map(ShiftApprovalDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public Optional<ShiftApprovalDto> getShiftApprovalById(@PathVariable Integer id) {
-        return this.shiftApprovalRepository.findById(id).map(ShiftApprovalDto::from);
+        return this.shiftApprovalService.findById(id).map(ShiftApprovalDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftApprovalDto createShiftApproval(@RequestBody ShiftApprovalDto shiftApproval) {
-        return ShiftApprovalDto.from(this.shiftApprovalRepository.save(shiftApproval.toEntity()));
+        return ShiftApprovalDto.from(this.shiftApprovalService.create(shiftApproval.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftApprovalDto updateShiftApproval(@PathVariable Integer id, @RequestBody ShiftApprovalDto shiftApprovalDetails) {
-        ShiftApproval shiftApproval = this.shiftApprovalRepository.findById(id).orElseThrow();
-        shiftApproval.setShiftAssignmentId(shiftApprovalDetails.shiftAssignmentId());
-        shiftApproval.setApproverEmployeeId(shiftApprovalDetails.approverEmployeeId());
-        shiftApproval.setDecision(shiftApprovalDetails.decision());
-        shiftApproval.setApprovalComment(shiftApprovalDetails.approvalComment());
-        shiftApproval.setDecisionDatetime(shiftApprovalDetails.decisionDatetime());
-        return ShiftApprovalDto.from(this.shiftApprovalRepository.save(shiftApproval));
+        return this.shiftApprovalService.update(id, shiftApprovalDetails.toEntity())
+                .map(ShiftApprovalDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftApproval(@PathVariable Integer id) {
-        this.shiftApprovalRepository.deleteById(id);
+        this.shiftApprovalService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftapproval/ShiftApprovalService.java
@@ -1,0 +1,41 @@
+package dk.ek.shift_happens.shiftapproval;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftApprovalService {
+
+    private final ShiftApprovalRepository shiftApprovalRepository;
+
+    public List<ShiftApproval> findAll() {
+        return shiftApprovalRepository.findAll();
+    }
+
+    public Optional<ShiftApproval> findById(Integer id) {
+        return shiftApprovalRepository.findById(id);
+    }
+
+    public ShiftApproval create(ShiftApproval shiftApproval) {
+        return shiftApprovalRepository.save(shiftApproval);
+    }
+
+    public Optional<ShiftApproval> update(Integer id, ShiftApproval updates) {
+        return shiftApprovalRepository.findById(id).map(existing -> {
+            existing.setShiftAssignmentId(updates.getShiftAssignmentId());
+            existing.setApproverEmployeeId(updates.getApproverEmployeeId());
+            existing.setDecision(updates.getDecision());
+            existing.setApprovalComment(updates.getApprovalComment());
+            existing.setDecisionDatetime(updates.getDecisionDatetime());
+            return shiftApprovalRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftApprovalRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentController.java
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftAssignmentController {
 
-    private final ShiftAssignmentRepository shiftAssignmentRepository;
+    private final ShiftAssignmentService shiftAssignmentService;
     private final AuthHelper authHelper;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<ShiftAssignmentDto> getShiftAssignments(Authentication auth) {
         List<ShiftAssignment> assignments = authHelper.isEmployee(auth)
-                ? shiftAssignmentRepository.findByEmployeeId(authHelper.currentEmployeeId(auth))
-                : this.shiftAssignmentRepository.findAll();
+                ? shiftAssignmentService.findByEmployeeId(authHelper.currentEmployeeId(auth))
+                : shiftAssignmentService.findAll();
         return assignments.stream().map(ShiftAssignmentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public ShiftAssignmentDto getShiftAssignmentById(@PathVariable Integer id, Authentication auth) {
-        ShiftAssignment assignment = shiftAssignmentRepository.findById(id)
+        ShiftAssignment assignment = shiftAssignmentService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         if (authHelper.isEmployee(auth)
                 && !assignment.getEmployeeId().equals(authHelper.currentEmployeeId(auth))) {
@@ -42,25 +42,20 @@ public class ShiftAssignmentController {
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftAssignmentDto createShiftAssignment(@RequestBody ShiftAssignmentDto shiftAssignment) {
-        return ShiftAssignmentDto.from(this.shiftAssignmentRepository.save(shiftAssignment.toEntity()));
+        return ShiftAssignmentDto.from(shiftAssignmentService.create(shiftAssignment.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftAssignmentDto updateShiftAssignment(@PathVariable Integer id, @RequestBody ShiftAssignmentDto shiftAssignmentDetails) {
-        ShiftAssignment shiftAssignment = this.shiftAssignmentRepository.findById(id).orElseThrow();
-        shiftAssignment.setShiftId(shiftAssignmentDetails.shiftId());
-        shiftAssignment.setEmployeeId(shiftAssignmentDetails.employeeId());
-        shiftAssignment.setAssignmentStatus(shiftAssignmentDetails.assignmentStatus());
-        shiftAssignment.setAssignedDatetime(shiftAssignmentDetails.assignedDatetime());
-        shiftAssignment.setCheckInDatetime(shiftAssignmentDetails.checkInDatetime());
-        shiftAssignment.setCheckOutDatetime(shiftAssignmentDetails.checkOutDatetime());
-        return ShiftAssignmentDto.from(this.shiftAssignmentRepository.save(shiftAssignment));
+        return shiftAssignmentService.update(id, shiftAssignmentDetails.toEntity())
+                .map(ShiftAssignmentDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftAssignment(@PathVariable Integer id) {
-        this.shiftAssignmentRepository.deleteById(id);
+        shiftAssignmentService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftassignment/ShiftAssignmentService.java
@@ -1,0 +1,46 @@
+package dk.ek.shift_happens.shiftassignment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftAssignmentService {
+
+    private final ShiftAssignmentRepository shiftAssignmentRepository;
+
+    public List<ShiftAssignment> findAll() {
+        return shiftAssignmentRepository.findAll();
+    }
+
+    public List<ShiftAssignment> findByEmployeeId(Integer employeeId) {
+        return shiftAssignmentRepository.findByEmployeeId(employeeId);
+    }
+
+    public Optional<ShiftAssignment> findById(Integer id) {
+        return shiftAssignmentRepository.findById(id);
+    }
+
+    public ShiftAssignment create(ShiftAssignment shiftAssignment) {
+        return shiftAssignmentRepository.save(shiftAssignment);
+    }
+
+    public Optional<ShiftAssignment> update(Integer id, ShiftAssignment updates) {
+        return shiftAssignmentRepository.findById(id).map(existing -> {
+            existing.setShiftId(updates.getShiftId());
+            existing.setEmployeeId(updates.getEmployeeId());
+            existing.setAssignmentStatus(updates.getAssignmentStatus());
+            existing.setAssignedDatetime(updates.getAssignedDatetime());
+            existing.setCheckInDatetime(updates.getCheckInDatetime());
+            existing.setCheckOutDatetime(updates.getCheckOutDatetime());
+            return shiftAssignmentRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftAssignmentRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleController.java
@@ -12,40 +12,38 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftRequiredJobRoleController {
 
-    private final ShiftRequiredJobRoleRepository shiftRequiredJobRoleRepository;
+    private final ShiftRequiredJobRoleService shiftRequiredJobRoleService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<ShiftRequiredJobRoleDto> getShiftRequiredJobRoles() {
-        return this.shiftRequiredJobRoleRepository.findAll().stream()
+        return this.shiftRequiredJobRoleService.findAll().stream()
                 .map(ShiftRequiredJobRoleDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public Optional<ShiftRequiredJobRoleDto> getShiftRequiredJobRoleById(@PathVariable Integer id) {
-        return this.shiftRequiredJobRoleRepository.findById(id).map(ShiftRequiredJobRoleDto::from);
+        return this.shiftRequiredJobRoleService.findById(id).map(ShiftRequiredJobRoleDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftRequiredJobRoleDto createShiftRequiredJobRole(@RequestBody ShiftRequiredJobRoleDto shiftRequiredJobRole) {
-        return ShiftRequiredJobRoleDto.from(this.shiftRequiredJobRoleRepository.save(shiftRequiredJobRole.toEntity()));
+        return ShiftRequiredJobRoleDto.from(this.shiftRequiredJobRoleService.create(shiftRequiredJobRole.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftRequiredJobRoleDto updateShiftRequiredJobRole(@PathVariable Integer id, @RequestBody ShiftRequiredJobRoleDto shiftRequiredJobRoleDetails) {
-        ShiftRequiredJobRole shiftRequiredJobRole = this.shiftRequiredJobRoleRepository.findById(id).orElseThrow();
-        shiftRequiredJobRole.setShiftId(shiftRequiredJobRoleDetails.shiftId());
-        shiftRequiredJobRole.setJobRoleId(shiftRequiredJobRoleDetails.jobRoleId());
-        shiftRequiredJobRole.setRequiredEmployeeCount(shiftRequiredJobRoleDetails.requiredEmployeeCount());
-        return ShiftRequiredJobRoleDto.from(this.shiftRequiredJobRoleRepository.save(shiftRequiredJobRole));
+        return this.shiftRequiredJobRoleService.update(id, shiftRequiredJobRoleDetails.toEntity())
+                .map(ShiftRequiredJobRoleDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftRequiredJobRole(@PathVariable Integer id) {
-        this.shiftRequiredJobRoleRepository.deleteById(id);
+        this.shiftRequiredJobRoleService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftrequiredjobrole/ShiftRequiredJobRoleService.java
@@ -1,0 +1,39 @@
+package dk.ek.shift_happens.shiftrequiredjobrole;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftRequiredJobRoleService {
+
+    private final ShiftRequiredJobRoleRepository shiftRequiredJobRoleRepository;
+
+    public List<ShiftRequiredJobRole> findAll() {
+        return shiftRequiredJobRoleRepository.findAll();
+    }
+
+    public Optional<ShiftRequiredJobRole> findById(Integer id) {
+        return shiftRequiredJobRoleRepository.findById(id);
+    }
+
+    public ShiftRequiredJobRole create(ShiftRequiredJobRole shiftRequiredJobRole) {
+        return shiftRequiredJobRoleRepository.save(shiftRequiredJobRole);
+    }
+
+    public Optional<ShiftRequiredJobRole> update(Integer id, ShiftRequiredJobRole updates) {
+        return shiftRequiredJobRoleRepository.findById(id).map(existing -> {
+            existing.setShiftId(updates.getShiftId());
+            existing.setJobRoleId(updates.getJobRoleId());
+            existing.setRequiredEmployeeCount(updates.getRequiredEmployeeCount());
+            return shiftRequiredJobRoleRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftRequiredJobRoleRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShiftSwapController {
 
-    private final ShiftSwapRepository shiftSwapRepository;
+    private final ShiftSwapService shiftSwapService;
     private final AuthHelper authHelper;
 
     @GetMapping
@@ -24,9 +24,9 @@ public class ShiftSwapController {
         List<ShiftSwap> swaps;
         if (authHelper.isEmployee(auth)) {
             Integer self = authHelper.currentEmployeeId(auth);
-            swaps = shiftSwapRepository.findByEmployeeFromIdOrEmployeeToId(self, self);
+            swaps = shiftSwapService.findByEmployee(self);
         } else {
-            swaps = this.shiftSwapRepository.findAll();
+            swaps = shiftSwapService.findAll();
         }
         return swaps.stream().map(ShiftSwapDto::from).toList();
     }
@@ -34,7 +34,7 @@ public class ShiftSwapController {
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public ShiftSwapDto getShiftSwapById(@PathVariable Integer id, Authentication auth) {
-        ShiftSwap swap = shiftSwapRepository.findById(id)
+        ShiftSwap swap = shiftSwapService.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         if (authHelper.isEmployee(auth)) {
             Integer self = authHelper.currentEmployeeId(auth);
@@ -48,25 +48,20 @@ public class ShiftSwapController {
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapDto createShiftSwap(@RequestBody ShiftSwapDto shiftSwap) {
-        return ShiftSwapDto.from(this.shiftSwapRepository.save(shiftSwap.toEntity()));
+        return ShiftSwapDto.from(shiftSwapService.create(shiftSwap.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapDto updateShiftSwap(@PathVariable Integer id, @RequestBody ShiftSwapDto shiftSwapDetails) {
-        ShiftSwap shiftSwap = this.shiftSwapRepository.findById(id).orElseThrow();
-        shiftSwap.setOriginalShiftAssignmentId(shiftSwapDetails.originalShiftAssignmentId());
-        shiftSwap.setEmployeeFromId(shiftSwapDetails.employeeFromId());
-        shiftSwap.setEmployeeToId(shiftSwapDetails.employeeToId());
-        shiftSwap.setSwapStatus(shiftSwapDetails.swapStatus());
-        shiftSwap.setRequestDatetime(shiftSwapDetails.requestDatetime());
-        shiftSwap.setReason(shiftSwapDetails.reason());
-        return ShiftSwapDto.from(this.shiftSwapRepository.save(shiftSwap));
+        return shiftSwapService.update(id, shiftSwapDetails.toEntity())
+                .map(ShiftSwapDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftSwap(@PathVariable Integer id) {
-        this.shiftSwapRepository.deleteById(id);
+        shiftSwapService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/ShiftSwapService.java
@@ -1,0 +1,46 @@
+package dk.ek.shift_happens.shiftswap;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftSwapService {
+
+    private final ShiftSwapRepository shiftSwapRepository;
+
+    public List<ShiftSwap> findAll() {
+        return shiftSwapRepository.findAll();
+    }
+
+    public List<ShiftSwap> findByEmployee(Integer employeeId) {
+        return shiftSwapRepository.findByEmployeeFromIdOrEmployeeToId(employeeId, employeeId);
+    }
+
+    public Optional<ShiftSwap> findById(Integer id) {
+        return shiftSwapRepository.findById(id);
+    }
+
+    public ShiftSwap create(ShiftSwap shiftSwap) {
+        return shiftSwapRepository.save(shiftSwap);
+    }
+
+    public Optional<ShiftSwap> update(Integer id, ShiftSwap updates) {
+        return shiftSwapRepository.findById(id).map(existing -> {
+            existing.setOriginalShiftAssignmentId(updates.getOriginalShiftAssignmentId());
+            existing.setEmployeeFromId(updates.getEmployeeFromId());
+            existing.setEmployeeToId(updates.getEmployeeToId());
+            existing.setSwapStatus(updates.getSwapStatus());
+            existing.setRequestDatetime(updates.getRequestDatetime());
+            existing.setReason(updates.getReason());
+            return shiftSwapRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftSwapRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jController.java
@@ -1,12 +1,9 @@
 package dk.ek.shift_happens.shiftswap.neo4j;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -15,18 +12,16 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ShiftSwapNeo4jController {
 
-    private final ShiftSwapNeo4jRepository shiftSwapNeo4jRepository;
-    private final Neo4jClient neo4jClient;
     private final ShiftSwapNeo4jService shiftSwapNeo4jService;
 
     @GetMapping
     public List<ShiftSwapNodeDto> getAll() {
-        return shiftSwapNeo4jRepository.findAll().stream().map(ShiftSwapNodeDto::from).toList();
+        return shiftSwapNeo4jService.findAll().stream().map(ShiftSwapNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ShiftSwapNodeDto> getById(@PathVariable Long id) {
-        return shiftSwapNeo4jRepository.findById(id)
+        return shiftSwapNeo4jService.findById(id)
                 .map(ShiftSwapNodeDto::from)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -34,83 +29,13 @@ public class ShiftSwapNeo4jController {
 
     @GetMapping("/candidates/{shiftId}")
     public ResponseEntity<List<Map<String, Object>>> getSwapCandidates(@PathVariable Integer shiftId) {
-        String cypher = """
-                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
-                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
-                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
-                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
-                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
-                  }
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
-                      WHERE other.startDatetime < target.endDatetime
-                        AND other.endDatetime > target.startDatetime
-                  }
-                OPTIONAL MATCH (candidate)-[:WORKS_AT_LOCATION]->(location:WorkLocation)
-                  WITH target, targetDepartment, candidate, location,
-                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
-                RETURN target.shiftId AS shiftId,
-                       target.shiftName AS shiftName,
-                       candidate.employeeId AS employeeId,
-                       candidate.employeeNumber AS employeeNumber,
-                       candidate.firstName AS firstName,
-                       candidate.lastName AS lastName,
-                       candidate.email AS email,
-                      targetDepartment.departmentName AS department,
-                       location.locationName AS location,
-                       matchingRoles
-                ORDER BY candidate.firstName, candidate.lastName
-                """;
-
-        return ResponseEntity.ok(runCandidateQuery(cypher, shiftId));
+        return ResponseEntity.ok(shiftSwapNeo4jService.findSwapCandidates(shiftId));
     }
 
     //kræver lige nu auth adgang, jeg tro fordi den bruger nået employe data som kun må tilgås som manager.
     @GetMapping("/candidates/location/{shiftId}")
     public ResponseEntity<List<Map<String, Object>>> getSwapCandidatesSameDepartmentAndLocation(@PathVariable Integer shiftId) {
-        String cypher = """
-                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
-                MATCH (target)-[:SHIFT_AT_LOCATION]->(targetLocation:WorkLocation)
-                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
-                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
-                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
-                MATCH (candidate)-[:WORKS_AT_LOCATION]->(targetLocation)
-                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
-                  }
-                  AND NOT EXISTS {
-                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
-                      WHERE other.startDatetime < target.endDatetime
-                        AND other.endDatetime > target.startDatetime
-                  }
-                WITH target, targetDepartment, targetLocation, candidate,
-                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
-                RETURN target.shiftId AS shiftId,
-                       target.shiftName AS shiftName,
-                       candidate.employeeId AS employeeId,
-                       candidate.employeeNumber AS employeeNumber,
-                       candidate.firstName AS firstName,
-                       candidate.lastName AS lastName,
-                       candidate.email AS email,
-                       targetDepartment.departmentName AS department,
-                       targetLocation.locationName AS location,
-                       matchingRoles
-                ORDER BY candidate.firstName, candidate.lastName
-                """;
-
-        return ResponseEntity.ok(runCandidateQuery(cypher, shiftId));
-    }
-
-    private List<Map<String, Object>> runCandidateQuery(String cypher, Integer shiftId) {
-        Collection<Map<String, Object>> rows = neo4jClient.query(cypher)
-                .bind(shiftId).to("shiftId")
-                .fetch()
-                .all();
-
-        return new ArrayList<>(rows);
+        return ResponseEntity.ok(shiftSwapNeo4jService.findSwapCandidatesSameDepartmentAndLocation(shiftId));
     }
 
     /**

--- a/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswap/neo4j/ShiftSwapNeo4jService.java
@@ -5,6 +5,9 @@ import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -12,7 +15,100 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftSwapNeo4jService {
 
+    private final ShiftSwapNeo4jRepository shiftSwapNeo4jRepository;
     private final Neo4jClient neo4jClient;
+
+    public List<ShiftSwapNode> findAll() {
+        return shiftSwapNeo4jRepository.findAll();
+    }
+
+    public Optional<ShiftSwapNode> findById(Long id) {
+        return shiftSwapNeo4jRepository.findById(id);
+    }
+
+    /**
+     * Returns swap candidates for a shift: active employees who hold a required
+     * role, work in the shift's department, and have no conflicting assignment.
+     */
+    public List<Map<String, Object>> findSwapCandidates(Integer shiftId) {
+        String cypher = """
+                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
+                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
+                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
+                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
+                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
+                  }
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
+                      WHERE other.startDatetime < target.endDatetime
+                        AND other.endDatetime > target.startDatetime
+                  }
+                OPTIONAL MATCH (candidate)-[:WORKS_AT_LOCATION]->(location:WorkLocation)
+                  WITH target, targetDepartment, candidate, location,
+                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
+                RETURN target.shiftId AS shiftId,
+                       target.shiftName AS shiftName,
+                       candidate.employeeId AS employeeId,
+                       candidate.employeeNumber AS employeeNumber,
+                       candidate.firstName AS firstName,
+                       candidate.lastName AS lastName,
+                       candidate.email AS email,
+                      targetDepartment.departmentName AS department,
+                       location.locationName AS location,
+                       matchingRoles
+                ORDER BY candidate.firstName, candidate.lastName
+                """;
+        return runCandidateQuery(cypher, shiftId);
+    }
+
+    /**
+     * As {@link #findSwapCandidates}, but additionally constrained to candidates
+     * who work at the shift's location.
+     */
+    public List<Map<String, Object>> findSwapCandidatesSameDepartmentAndLocation(Integer shiftId) {
+        String cypher = """
+                MATCH (target:Shift {shiftId: $shiftId})-[:SHIFT_IN_DEPT]->(targetDepartment:Department)
+                MATCH (target)-[:SHIFT_AT_LOCATION]->(targetLocation:WorkLocation)
+                MATCH (target)-[:REQUIRES_ROLE]->(requiredRole:JobRole)
+                MATCH (candidate:Employee)-[:HAS_JOB_ROLE]->(requiredRole)
+                MATCH (candidate)-[:WORKS_IN_DEPT]->(targetDepartment)
+                MATCH (candidate)-[:WORKS_AT_LOCATION]->(targetLocation)
+                WHERE coalesce(candidate.employmentStatus, '') = 'ACTIVE'
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(target)
+                  }
+                  AND NOT EXISTS {
+                      MATCH (candidate)-[:ASSIGNED_TO_SHIFT]->(other:Shift)
+                      WHERE other.startDatetime < target.endDatetime
+                        AND other.endDatetime > target.startDatetime
+                  }
+                WITH target, targetDepartment, targetLocation, candidate,
+                     collect(DISTINCT requiredRole.roleName) AS matchingRoles
+                RETURN target.shiftId AS shiftId,
+                       target.shiftName AS shiftName,
+                       candidate.employeeId AS employeeId,
+                       candidate.employeeNumber AS employeeNumber,
+                       candidate.firstName AS firstName,
+                       candidate.lastName AS lastName,
+                       candidate.email AS email,
+                       targetDepartment.departmentName AS department,
+                       targetLocation.locationName AS location,
+                       matchingRoles
+                ORDER BY candidate.firstName, candidate.lastName
+                """;
+        return runCandidateQuery(cypher, shiftId);
+    }
+
+    private List<Map<String, Object>> runCandidateQuery(String cypher, Integer shiftId) {
+        Collection<Map<String, Object>> rows = neo4jClient.query(cypher)
+                .bind(shiftId).to("shiftId")
+                .fetch()
+                .all();
+
+        return new ArrayList<>(rows);
+    }
 
     /**
      * Executes a shift swap inside a single Neo4j transaction:

--- a/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalController.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalController.java
@@ -12,41 +12,37 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ShiftSwapApprovalController {
 
-    private final ShiftSwapApprovalRepository shiftSwapApprovalRepository;
+    private final ShiftSwapApprovalService shiftSwapApprovalService;
 
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public List<ShiftSwapApprovalDto> getShiftSwapApprovals() {
-        return this.shiftSwapApprovalRepository.findAll().stream().map(ShiftSwapApprovalDto::from).toList();
+        return this.shiftSwapApprovalService.findAll().stream().map(ShiftSwapApprovalDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public Optional<ShiftSwapApprovalDto> getShiftSwapApprovalById(@PathVariable Integer id) {
-        return this.shiftSwapApprovalRepository.findById(id).map(ShiftSwapApprovalDto::from);
+        return this.shiftSwapApprovalService.findById(id).map(ShiftSwapApprovalDto::from);
     }
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapApprovalDto createShiftSwapApproval(@RequestBody ShiftSwapApprovalDto shiftSwapApproval) {
-        return ShiftSwapApprovalDto.from(this.shiftSwapApprovalRepository.save(shiftSwapApproval.toEntity()));
+        return ShiftSwapApprovalDto.from(this.shiftSwapApprovalService.create(shiftSwapApproval.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public ShiftSwapApprovalDto updateShiftSwapApproval(@PathVariable Integer id, @RequestBody ShiftSwapApprovalDto shiftSwapApprovalDetails) {
-        ShiftSwapApproval shiftSwapApproval = this.shiftSwapApprovalRepository.findById(id).orElseThrow();
-        shiftSwapApproval.setShiftSwapId(shiftSwapApprovalDetails.shiftSwapId());
-        shiftSwapApproval.setApproverEmployeeId(shiftSwapApprovalDetails.approverEmployeeId());
-        shiftSwapApproval.setDecision(shiftSwapApprovalDetails.decision());
-        shiftSwapApproval.setShiftSwapComment(shiftSwapApprovalDetails.shiftSwapComment());
-        shiftSwapApproval.setDecisionDatetime(shiftSwapApprovalDetails.decisionDatetime());
-        return ShiftSwapApprovalDto.from(this.shiftSwapApprovalRepository.save(shiftSwapApproval));
+        return this.shiftSwapApprovalService.update(id, shiftSwapApprovalDetails.toEntity())
+                .map(ShiftSwapApprovalDto::from)
+                .orElseThrow();
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public void deleteShiftSwapApproval(@PathVariable Integer id) {
-        this.shiftSwapApprovalRepository.deleteById(id);
+        this.shiftSwapApprovalService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalService.java
+++ b/src/main/java/dk/ek/shift_happens/shiftswapapproval/ShiftSwapApprovalService.java
@@ -1,0 +1,41 @@
+package dk.ek.shift_happens.shiftswapapproval;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftSwapApprovalService {
+
+    private final ShiftSwapApprovalRepository shiftSwapApprovalRepository;
+
+    public List<ShiftSwapApproval> findAll() {
+        return shiftSwapApprovalRepository.findAll();
+    }
+
+    public Optional<ShiftSwapApproval> findById(Integer id) {
+        return shiftSwapApprovalRepository.findById(id);
+    }
+
+    public ShiftSwapApproval create(ShiftSwapApproval shiftSwapApproval) {
+        return shiftSwapApprovalRepository.save(shiftSwapApproval);
+    }
+
+    public Optional<ShiftSwapApproval> update(Integer id, ShiftSwapApproval updates) {
+        return shiftSwapApprovalRepository.findById(id).map(existing -> {
+            existing.setShiftSwapId(updates.getShiftSwapId());
+            existing.setApproverEmployeeId(updates.getApproverEmployeeId());
+            existing.setDecision(updates.getDecision());
+            existing.setShiftSwapComment(updates.getShiftSwapComment());
+            existing.setDecisionDatetime(updates.getDecisionDatetime());
+            return shiftSwapApprovalRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        shiftSwapApprovalRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationController.java
@@ -13,18 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkLocationController {
 
-    private final WorkLocationRepository workLocationRepository;
+    private final WorkLocationService workLocationService;
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public List<WorkLocationDto> getAll() {
-        return workLocationRepository.findAll().stream().map(WorkLocationDto::from).toList();
+        return workLocationService.findAll().stream().map(WorkLocationDto::from).toList();
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
     public WorkLocationDto getById(@PathVariable Integer id) {
-        return workLocationRepository.findById(id)
+        return workLocationService.findById(id)
                 .map(WorkLocationDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
@@ -33,28 +33,21 @@ public class WorkLocationController {
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.CREATED)
     public WorkLocationDto create(@RequestBody WorkLocationDto workLocation) {
-        return WorkLocationDto.from(workLocationRepository.save(workLocation.toEntity()));
+        return WorkLocationDto.from(workLocationService.create(workLocation.toEntity()));
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     public WorkLocationDto update(@PathVariable Integer id, @RequestBody WorkLocationDto details) {
-        WorkLocation existing = workLocationRepository.findById(id)
+        return workLocationService.update(id, details.toEntity())
+                .map(WorkLocationDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        existing.setLocationName(details.locationName());
-        existing.setAddressLine1(details.addressLine1());
-        existing.setAddressLine2(details.addressLine2());
-        existing.setCity(details.city());
-        existing.setCountry(details.country());
-        existing.setTimezone(details.timezone());
-        existing.setIsActive(details.isActive());
-        return WorkLocationDto.from(workLocationRepository.save(existing));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMINISTRATOR','MANAGER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer id) {
-        workLocationRepository.deleteById(id);
+        workLocationService.delete(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationService.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/WorkLocationService.java
@@ -1,0 +1,43 @@
+package dk.ek.shift_happens.worklocation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkLocationService {
+
+    private final WorkLocationRepository workLocationRepository;
+
+    public List<WorkLocation> findAll() {
+        return workLocationRepository.findAll();
+    }
+
+    public Optional<WorkLocation> findById(Integer id) {
+        return workLocationRepository.findById(id);
+    }
+
+    public WorkLocation create(WorkLocation workLocation) {
+        return workLocationRepository.save(workLocation);
+    }
+
+    public Optional<WorkLocation> update(Integer id, WorkLocation updates) {
+        return workLocationRepository.findById(id).map(existing -> {
+            existing.setLocationName(updates.getLocationName());
+            existing.setAddressLine1(updates.getAddressLine1());
+            existing.setAddressLine2(updates.getAddressLine2());
+            existing.setCity(updates.getCity());
+            existing.setCountry(updates.getCountry());
+            existing.setTimezone(updates.getTimezone());
+            existing.setIsActive(updates.getIsActive());
+            return workLocationRepository.save(existing);
+        });
+    }
+
+    public void delete(Integer id) {
+        workLocationRepository.deleteById(id);
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoController.java
@@ -12,41 +12,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkLocationMongoController {
 
-    private final WorkLocationMongoRepository workLocationMongoRepository;
+    private final WorkLocationMongoService workLocationMongoService;
 
     @GetMapping
     public List<WorkLocationDocumentDto> getAll() {
-        return workLocationMongoRepository.findAll().stream().map(WorkLocationDocumentDto::from).toList();
+        return workLocationMongoService.findAll().stream().map(WorkLocationDocumentDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public WorkLocationDocumentDto getById(@PathVariable String id) {
-        return workLocationMongoRepository.findById(id)
+        return workLocationMongoService.findById(id)
                 .map(WorkLocationDocumentDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping
     public WorkLocationDocumentDto create(@RequestBody WorkLocationDocumentDto workLocation) {
-        return WorkLocationDocumentDto.from(workLocationMongoRepository.save(workLocation.toEntity()));
+        return WorkLocationDocumentDto.from(workLocationMongoService.create(workLocation.toEntity()));
     }
 
     @PutMapping("/{id}")
     public WorkLocationDocumentDto update(@PathVariable String id, @RequestBody WorkLocationDocumentDto workLocation) {
-        if (!workLocationMongoRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
-        WorkLocationDocument entity = workLocation.toEntity();
-        entity.setId(id);
-        return WorkLocationDocumentDto.from(workLocationMongoRepository.save(entity));
+        return workLocationMongoService.update(id, workLocation.toEntity())
+                .map(WorkLocationDocumentDto::from)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String id) {
-        if (!workLocationMongoRepository.existsById(id)) {
+        if (!workLocationMongoService.delete(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        workLocationMongoRepository.deleteById(id);
     }
 }

--- a/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/mongo/WorkLocationMongoService.java
@@ -1,0 +1,42 @@
+package dk.ek.shift_happens.worklocation.mongo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkLocationMongoService {
+
+    private final WorkLocationMongoRepository workLocationMongoRepository;
+
+    public List<WorkLocationDocument> findAll() {
+        return workLocationMongoRepository.findAll();
+    }
+
+    public Optional<WorkLocationDocument> findById(String id) {
+        return workLocationMongoRepository.findById(id);
+    }
+
+    public WorkLocationDocument create(WorkLocationDocument document) {
+        return workLocationMongoRepository.save(document);
+    }
+
+    public Optional<WorkLocationDocument> update(String id, WorkLocationDocument document) {
+        if (!workLocationMongoRepository.existsById(id)) {
+            return Optional.empty();
+        }
+        document.setId(id);
+        return Optional.of(workLocationMongoRepository.save(document));
+    }
+
+    public boolean delete(String id) {
+        if (!workLocationMongoRepository.existsById(id)) {
+            return false;
+        }
+        workLocationMongoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jController.java
@@ -12,16 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkLocationNeo4jController {
 
-    private final WorkLocationNeo4jRepository workLocationNeo4jRepository;
+    private final WorkLocationNeo4jService workLocationNeo4jService;
 
     @GetMapping
     public List<WorkLocationNodeDto> getAll() {
-        return workLocationNeo4jRepository.findAll().stream().map(WorkLocationNodeDto::from).toList();
+        return workLocationNeo4jService.findAll().stream().map(WorkLocationNodeDto::from).toList();
     }
 
     @GetMapping("/{id}")
     public WorkLocationNodeDto getById(@PathVariable Long id) {
-        return workLocationNeo4jRepository.findById(id)
+        return workLocationNeo4jService.findById(id)
                 .map(WorkLocationNodeDto::from)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }

--- a/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/worklocation/neo4j/WorkLocationNeo4jService.java
@@ -1,0 +1,22 @@
+package dk.ek.shift_happens.worklocation.neo4j;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkLocationNeo4jService {
+
+    private final WorkLocationNeo4jRepository workLocationNeo4jRepository;
+
+    public List<WorkLocationNode> findAll() {
+        return workLocationNeo4jRepository.findAll();
+    }
+
+    public Optional<WorkLocationNode> findById(Long id) {
+        return workLocationNeo4jRepository.findById(id);
+    }
+}


### PR DESCRIPTION
## What

Applies the assignment's layered architecture — *"controllers -> services ->
models / repositories"* — uniformly across all three stores.

Before this change only **5 of 17 JPA controllers** had a service; the Mongo
and Neo4j controllers called repositories directly.

| Store | Controllers | Services added |
|---|---|---|
| JPA   | 17 | 12 (5 already existed) |
| Mongo | 8  | 8 |
| Neo4j | 10 | 9 (`ShiftSwapNeo4jService` already existed — extended) |

**All 35 controllers now depend on a service, never a repository directly.**

## Design

- **Thin delegating services** — `@Service @RequiredArgsConstructor`, holding
  the repository, exposing `findAll / findById / create / update / delete`. No
  business logic invented (that would be speculative).
- **`findById` / `update` return `Optional`** — the service stays free of HTTP
  concerns; the controller maps to the HTTP response. Follows the existing
  `LeaveRequestService.patch` precedent.
- **Behaviour preserved** — `update` field-copy logic moved verbatim from
  controllers into services; status codes unchanged.
- **`ShiftSwapNeo4jService`** extended with `findAll` / `findById` and the two
  Cypher candidate-queries, so its controller no longer touches `Neo4jClient`
  or the repository directly.

See `docs/service-layer.md` for the full rationale.

## Verification

- `mvn compile` — clean.
- `mvn test` — **6/6 pass** (`BUILD SUCCESS`).

## Known follow-ups (out of scope)

- **No `@PreAuthorize` on Mongo / Neo4j controllers** — a separate security
  concern.
- Older services (`DepartmentService`) throw from `findById`; new ones return
  `Optional`. Minor style divergence, could be aligned later.

---

Note: stacked on #112 → #111 → #109. Bases retarget as the lower PRs merge.