### PR TITLE
Fix duplicate db_user column breaking MySQL init

### DIFF
--- a/docker/init/01-schema.sql
+++ b/docker/init/01-schema.sql
@@ -245,6 +245,3 @@ CREATE INDEX idx_leave_employee ON leave_request (employee_id);
 
 ALTER TABLE shift_assignment
     ADD CONSTRAINT uq_shift_employee UNIQUE (shift_id, employee_id);
-
-ALTER TABLE audit_log
-ADD COLUMN db_user VARCHAR(100) NULL AFTER action_type;


### PR DESCRIPTION
## Problem

`make run-all` fails on a fresh start — the `shift-happens-db` container exits 1:

```
ERROR 1060 (42S21) at line 249: Duplicate column name 'db_user'
```

`docker/init/01-schema.sql` declares `db_user` twice on `audit_log`:
- in the `CREATE TABLE audit_log` statement, and
- again in a trailing `ALTER TABLE audit_log ADD COLUMN db_user ...`.

MySQL runs the init scripts on first boot, hits the duplicate, and aborts.

## Fix

Remove the redundant `ALTER TABLE audit_log` — the column already exists in `CREATE TABLE`.

## Verification

`docker compose down -v && docker compose up -d --wait db mongodb neo4j` — all three containers reach healthy, DB init runs with no errors.