### PR TITLE
feat: paging, sorting and filtering for employee endpoints

### DIFF
--- a/src/main/java/dk/ek/shift_happens/employee/EmployeeController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/EmployeeController.java
@@ -1,8 +1,13 @@
 package dk.ek.shift_happens.employee;
 
 import dk.ek.shift_happens.auth.AuthHelper;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -21,15 +26,44 @@ public class EmployeeController {
 
     @GetMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<EmployeeDto>> getEmployees(Authentication auth) {
-        List<Employee> employees;
+    public ResponseEntity<Page<EmployeeDto>> getEmployees(
+            @RequestParam(required = false) String employmentStatus,
+            @RequestParam(required = false) Integer primaryWorkLocationId,
+            @RequestParam(required = false) UserRole userRole,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String firstName,
+            @RequestParam(required = false) String lastName,
+            @ParameterObject Pageable pageable,
+            Authentication auth) {
         if (authHelper.isEmployee(auth)) {
             Integer selfId = authHelper.currentEmployeeId(auth);
-            employees = this.employeeService.findById(selfId).map(List::of).orElse(List.of());
+            Specification<Employee> spec = (root, query, cb) -> cb.equal(root.get("employeeId"), selfId);
+            Page<EmployeeDto> page = this.employeeService.findAll(spec, pageable).map(EmployeeDto::from);
+            return ResponseEntity.ok(page);
         } else {
-            employees = this.employeeService.findAll();
+            Specification<Employee> spec = (root, query, cb) -> cb.conjunction();
+            if (employmentStatus != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("employmentStatus"), employmentStatus));
+            }
+            if (primaryWorkLocationId != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("primaryWorkLocationId"), primaryWorkLocationId));
+            }
+            if (userRole != null) {
+                spec = spec.and((root, query, cb) -> cb.equal(root.get("userRole"), userRole));
+            }
+            if (email != null) {
+                spec = spec.and((root, query, cb) -> cb.like(cb.lower(root.get("email")), "%" + email.toLowerCase() + "%"));
+            }
+            if (firstName != null) {
+                spec = spec.and((root, query, cb) -> cb.like(cb.lower(root.get("firstName")), "%" + firstName.toLowerCase() + "%"));
+            }
+            if (lastName != null) {
+                spec = spec.and((root, query, cb) -> cb.like(cb.lower(root.get("lastName")), "%" + lastName.toLowerCase() + "%"));
+            }
+
+            Page<EmployeeDto> page = this.employeeService.findAll(spec, pageable).map(EmployeeDto::from);
+            return ResponseEntity.ok(page);
         }
-        return ResponseEntity.ok(employees.stream().map(EmployeeDto::from).toList());
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/employee/EmployeeRepository.java
+++ b/src/main/java/dk/ek/shift_happens/employee/EmployeeRepository.java
@@ -1,11 +1,12 @@
 package dk.ek.shift_happens.employee;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface EmployeeRepository extends JpaRepository<Employee, Integer> {
+public interface EmployeeRepository extends JpaRepository<Employee, Integer>, JpaSpecificationExecutor<Employee> {
     Optional<Employee> findByEmail(String email);
 }

--- a/src/main/java/dk/ek/shift_happens/employee/EmployeeService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/EmployeeService.java
@@ -1,6 +1,9 @@
 package dk.ek.shift_happens.employee;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +29,10 @@ public class EmployeeService {
 
     public List<Employee> findAll() {
         return this.employeeRepository.findAll();
+    }
+
+    public Page<Employee> findAll(Specification<Employee> spec, Pageable pageable) {
+        return this.employeeRepository.findAll(spec, pageable);
     }
 
     public Optional<Employee> findById(Integer id) {

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoController.java
@@ -1,7 +1,11 @@
 package dk.ek.shift_happens.employee.mongo;
 
+import dk.ek.shift_happens.employee.UserRole;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -17,8 +21,16 @@ public class EmployeeMongoController {
     private final EmployeeMongoService employeeMongoService;
 
     @GetMapping
-    public List<EmployeeDocumentDto> getAll() {
-        return employeeMongoService.findAll().stream().map(EmployeeDocumentDto::from).toList();
+    public Page<EmployeeDocumentDto> getAll(
+            @RequestParam(required = false) String employmentStatus,
+            @RequestParam(required = false) Integer primaryWorkLocationId,
+            @RequestParam(required = false) String userRole,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String firstName,
+            @RequestParam(required = false) String lastName,
+            @ParameterObject Pageable pageable) {
+        return employeeMongoService.findAll(employmentStatus, primaryWorkLocationId, userRole, email, firstName, lastName, pageable)
+                .map(EmployeeDocumentDto::from);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/mongo/EmployeeMongoService.java
@@ -1,6 +1,13 @@
 package dk.ek.shift_happens.employee.mongo;
 
+import dk.ek.shift_happens.employee.UserRole;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,9 +18,37 @@ import java.util.Optional;
 public class EmployeeMongoService {
 
     private final EmployeeMongoRepository employeeMongoRepository;
+    private final MongoTemplate mongoTemplate;
 
     public List<EmployeeDocument> findAll() {
         return employeeMongoRepository.findAll();
+    }
+
+    public Page<EmployeeDocument> findAll(String employmentStatus, Integer primaryWorkLocationId, String userRole, String email, String firstName, String lastName, Pageable pageable) {
+        Query query = new Query().with(pageable);
+        if (employmentStatus != null) {
+            query.addCriteria(Criteria.where("employmentStatus").is(employmentStatus));
+        }
+        if (primaryWorkLocationId != null) {
+            query.addCriteria(Criteria.where("primaryWorkLocation.workLocationId").is(primaryWorkLocationId));
+        }
+        if (userRole != null) {
+            query.addCriteria(Criteria.where("userRole").is(userRole));
+        }
+        if (email != null) {
+            query.addCriteria(Criteria.where("email").regex(email, "i"));
+        }
+        if (firstName != null) {
+            query.addCriteria(Criteria.where("firstName").regex(firstName, "i"));
+        }
+        if (lastName != null) {
+            query.addCriteria(Criteria.where("lastName").regex(lastName, "i"));
+        }
+
+        long total = mongoTemplate.count(Query.of(query).limit(-1).skip(-1), EmployeeDocument.class);
+        List<EmployeeDocument> list = mongoTemplate.find(query, EmployeeDocument.class);
+
+        return new PageImpl<>(list, pageable, total);
     }
 
     public Optional<EmployeeDocument> findById(Integer id) {

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jController.java
@@ -2,6 +2,9 @@ package dk.ek.shift_happens.employee.neo4j;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -17,8 +20,16 @@ public class EmployeeNeo4jController {
     private final EmployeeNeo4jService employeeNeo4jService;
 
     @GetMapping
-    public List<EmployeeNodeDto> getAll() {
-        return employeeNeo4jService.findAll().stream().map(EmployeeNodeDto::from).toList();
+    public Page<EmployeeNodeDto> getAll(
+            @RequestParam(required = false) String employmentStatus,
+            @RequestParam(required = false) Integer primaryWorkLocationId,
+            @RequestParam(required = false) String userRole,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String firstName,
+            @RequestParam(required = false) String lastName,
+            @ParameterObject Pageable pageable) {
+        return employeeNeo4jService.findAll(employmentStatus, primaryWorkLocationId, userRole, email, firstName, lastName, pageable)
+                .map(EmployeeNodeDto::from);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jService.java
+++ b/src/main/java/dk/ek/shift_happens/employee/neo4j/EmployeeNeo4jService.java
@@ -1,19 +1,88 @@
 package dk.ek.shift_happens.employee.neo4j;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.neo4j.core.Neo4jClient;
+import org.springframework.data.neo4j.core.Neo4jTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class EmployeeNeo4jService {
-
     private final EmployeeNeo4jRepository employeeNeo4jRepository;
+    private final Neo4jTemplate neo4jTemplate;
+    private final Neo4jClient neo4jClient;
 
     public List<EmployeeNode> findAll() {
         return employeeNeo4jRepository.findAll();
+    }
+
+    public Page<EmployeeNode> findAll(String employmentStatus, Integer primaryWorkLocationId, String userRole, String email, String firstName, String lastName, Pageable pageable) {
+        StringBuilder filterBuilder = new StringBuilder("WHERE 1=1 ");
+        Map<String, Object> parameters = new HashMap<>();
+
+        if (employmentStatus != null) {
+            filterBuilder.append("AND n.employmentStatus = $employmentStatus ");
+            parameters.put("employmentStatus", employmentStatus);
+        }
+        if (primaryWorkLocationId != null) {
+            filterBuilder.append("AND n.primaryWorkLocationId = $primaryWorkLocationId ");
+            parameters.put("primaryWorkLocationId", primaryWorkLocationId);
+        }
+        if (userRole != null) {
+            filterBuilder.append("AND n.userRole = $userRole ");
+            parameters.put("userRole", userRole);
+        }
+        if (email != null) {
+            filterBuilder.append("AND n.email CONTAINS $email ");
+            parameters.put("email", email);
+        }
+        if (firstName != null) {
+            filterBuilder.append("AND n.firstName CONTAINS $firstName ");
+            parameters.put("firstName", firstName);
+        }
+        if (lastName != null) {
+            filterBuilder.append("AND n.lastName CONTAINS $lastName ");
+            parameters.put("lastName", lastName);
+        }
+
+        String countQuery = "MATCH (n:Employee) " + filterBuilder.toString() + " RETURN count(n) AS count";
+        Long total = neo4jClient
+                .query(countQuery)
+                .bindAll(parameters)
+                .fetchAs(Long.class)
+                .one()
+                .orElse(0L);
+
+        StringBuilder queryBuilder = new StringBuilder("MATCH (n:Employee) ");
+        queryBuilder.append(filterBuilder);
+
+        // Sorting
+        if (pageable.getSort().isSorted()) {
+            queryBuilder.append("ORDER BY ");
+            pageable.getSort().forEach(order -> {
+                queryBuilder.append("n.").append(order.getProperty()).append(" ").append(order.getDirection().name()).append(", ");
+            });
+            queryBuilder.setLength(queryBuilder.length() - 2); // remove last comma
+            queryBuilder.append(" ");
+        }
+
+        // Paging
+        queryBuilder.append("SKIP ").append(pageable.getOffset()).append(" ");
+        queryBuilder.append("LIMIT ").append(pageable.getPageSize()).append(" ");
+        queryBuilder.append("RETURN n");
+
+        List<EmployeeNode> list = neo4jTemplate.findAll(queryBuilder.toString(), parameters, EmployeeNode.class);
+
+        return new PageImpl<>(list, pageable, total);
     }
 
     public Optional<EmployeeNode> findById(Long id) {


### PR DESCRIPTION
This PR adds paging, sorting, and filtering capabilities to the Employee endpoints across SQL (MySQL), MongoDB, and Neo4j implementations.

### Summary
- Added paging, sorting, and filtering capabilities to the Employee endpoints.

### Changes
- **SQL (JPA)**: Updated `EmployeeController` and `EmployeeService` to support JPA Specifications for dynamic filtering.
- **MongoDB**: Enhanced `EmployeeMongoService` to build dynamic queries using `MongoTemplate`, fixing a bug where paging parameters were being ignored.
- **Neo4j**: Implemented custom Cypher query generation in `EmployeeNeo4jService` using `Neo4jClient` to handle scalar count results and `Neo4jTemplate` for paged data.
- **OpenAPI**: Integrated `@ParameterObject` annotations to ensure correct documentation of pagination and sorting parameters in Swagger UI.

### Verification
- Verified that all three database types support consistent filtering parameters and pagination logic.
- Fixed `java.lang.IllegalArgumentException: Cannot get or create persistent entity` in Neo4j by switching to `Neo4jClient` for count queries.
- Fixed MongoDB paging issue where the full list was returned regardless of page size.