### PR TITLE
Add isolated Docker test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,41 @@ db-shell:
 	docker exec -it shift-happens-db mysql -u root -p$(MYSQL_ROOT_PASSWORD) $(MYSQL_DATABASE)
 
 # ──────────────────────────────────────────────────────────────
+# Testing  (isolated, throwaway Docker DBs — never touches dev data)
+# ──────────────────────────────────────────────────────────────
+
+# Run the test stack under its own compose project so it stays isolated from dev.
+TEST_COMPOSE = docker compose -p shift-happens-test -f docker-compose.test.yml
+
+# Connection settings that point the test run at the test stack's ports.
+# These override the dev values exported from .env, just for ./mvnw test.
+TEST_ENV = \
+	DB_URL="jdbc:mysql://127.0.0.1:3308/$(MYSQL_DATABASE)?serverTimezone=UTC" \
+	DB_USERNAME=root \
+	DB_PASSWORD="$(MYSQL_ROOT_PASSWORD)" \
+	MONGO_URI="mongodb://127.0.0.1:27018/$(MYSQL_DATABASE)" \
+	NEO4J_URI="bolt://127.0.0.1:7688" \
+	NEO4J_USERNAME="$(NEO4J_USERNAME)" \
+	NEO4J_PASSWORD="$(NEO4J_PASSWORD)" \
+	JWT_SECRET="$(JWT_SECRET)" \
+	PASSWORD_PEPPER="$(PASSWORD_PEPPER)"
+
+## Start the throwaway test databases (MySQL/Mongo/Neo4j) on test ports
+test-up:
+	$(TEST_COMPOSE) up -d --wait
+
+## Stop the test databases and wipe their data
+test-down:
+	$(TEST_COMPOSE) down -v
+
+## Spin up test DBs, run the full test suite against them, then tear them down
+test:
+	@set -e; \
+	trap '$(TEST_COMPOSE) down -v' EXIT; \
+	$(TEST_COMPOSE) up -d --wait; \
+	$(TEST_ENV) ./mvnw test
+
+# ──────────────────────────────────────────────────────────────
 # Load Dumps  (restore committed seed data into live containers)
 # ──────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ If you have `make` installed, these wrap the docker/maven commands above:
 | `make down` | `docker compose down` |
 | `make clean` | `docker compose down -v` |
 | `make db-shell` | Open MySQL CLI inside the container |
+| `make test` | Spin up isolated test DBs, run `./mvnw test`, then tear them down |
+| `make test-up` | Start the throwaway test DBs only (ports 3308 / 27018 / 7688) |
+| `make test-down` | Stop the test DBs and wipe their data |
 
 ---
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,49 @@
+# Throwaway test stack — isolated databases for `make test`.
+# No app, no named volumes (data lives in the container layer and is wiped on
+# `down`), and ports are offset from dev so this runs alongside docker-compose.yml.
+# Always invoke via the Makefile, which runs it under its own compose project
+# name (-p shift-happens-test) to keep containers/networks separate from dev.
+services:
+  db:
+    image: mysql:8.0
+    container_name: shift-happens-test-db
+    command: --event-scheduler=ON --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      APP_DB_USER: ${APP_DB_USER}
+      APP_DB_PASSWORD: ${APP_DB_PASSWORD}
+    ports:
+      - "3308:3306"
+    volumes:
+      - ./docker/init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "mysql", "-uroot", "-p${MYSQL_ROOT_PASSWORD}", "-e", "SELECT 1 FROM ${MYSQL_DATABASE}.employee LIMIT 1;"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mongodb:
+    image: mongo:7
+    container_name: shift-happens-test-mongo
+    ports:
+      - "27018:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  neo4j:
+    image: neo4j:5
+    container_name: shift-happens-test-neo4j
+    ports:
+      - "7475:7474"
+      - "7688:7687"
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD}
+    healthcheck:
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "${NEO4J_PASSWORD}", "RETURN 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 20


### PR DESCRIPTION
## What

Adds a throwaway Docker test stack so the suite (incl. the `@SpringBootTest` context-load test) can run against real databases without touching dev data.

- **`docker-compose.test.yml`** (new) — MySQL/Mongo/Neo4j only, no app. Offset ports (`3308` / `27018` / `7688`+`7475`) so it runs alongside the dev stack, and **no named volumes** so data is wiped on teardown. Reuses `docker/init` for the MySQL schema (needed for `ddl-auto=validate`).
- **`Makefile`** — new *Testing* section:
  - `make test` — spin up test DBs → `./mvnw test` (pointed at test ports) → tear down
  - `make test-up` / `make test-down` — start / wipe the test DBs only
- **`README.md`** — documents the three targets in the Make Commands table.

## Isolation

Runs under its own compose project (`-p shift-happens-test`), so no collision with `docker-compose.yml`. Test-only connection settings override the `.env` dev values just for that `./mvnw test` run — dev DBs and seed data are untouched. Teardown uses a shell `trap ... EXIT` so the DBs are wiped even if tests fail, while `set -e` still propagates the failure.

No Java or `pom.xml` changes.

## Verification

`make test` run locally: **`Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`** — BUILD SUCCESS, including `contextLoads()` booting the full app against all three test DBs. Containers torn down automatically afterward.