### PR TITLE
fix: include neo4j init containers in Makefile startup targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ export
 
 ## Start all 3 databases in the background, then run the Spring Boot app locally
 run-all:
-	docker compose up -d --wait db mongodb neo4j
+	docker compose up -d --wait db mongodb neo4j neo4j-init neo4j-init-indexes
 	@echo "MySQL is ready."
 	./mvnw spring-boot:run
 
 ## Start all 3 databases in the background only (no app)
 run-dbs:
-	docker compose up -d --wait db mongodb neo4j
+	docker compose up -d --wait db mongodb neo4j neo4j-init neo4j-init-indexes
 
 ## Run the Spring Boot app locally (databases must already be running)
 run-app:
@@ -27,7 +27,7 @@ db:
 ## Nuke all volumes and restart databases fresh (re-runs all init scripts)
 reset:
 	docker compose down -v
-	docker compose up -d --wait db mongodb neo4j
+	docker compose up -d --wait db mongodb neo4j neo4j-init neo4j-init-indexes
 
 ## Stop everything
 down:


### PR DESCRIPTION
run-all, run-dbs, and reset were not starting neo4j-init and neo4j-init-indexes, so constraints and indexes were never applied on fresh environments.